### PR TITLE
Add launch.json for each of the bridge services

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug location server",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/location/main.go",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "Debug rhoai-normalizer",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/rhoai-normalizer/main.go",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "Debug storage-rest",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/storage-rest/main.go",
+            "cwd": "${workspaceFolder}"
+        }
+
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ Either via the command line, or from your favorite Golang editor, set the follow
 ### location
 
 1. None of the above env vars are needed at this time.
+
+### Debugging (VS Code)
+
+To debug the bridge services in VS Code, a launch.json file has been provided with options to debug each of the individual services. Ensure that you launch VS Code from the same terminal window that has the above environment variables set.


### PR DESCRIPTION
Adds a basic launch.json for debugging the three bridge services, plus a small addition to the README