### PR TITLE
[RHDHPAI-608] Define JSON schema for generating model catalog entities

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -34,8 +34,21 @@ jobs:
       - name: unit test
         run: make test
 
-      # Runs a set of commands using the runners shell
-      # - name: Run a multi-line script
-      #  run: |
-      #    echo Add other actions to build,
-      #    echo test, and deploy your project.
+  validate-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # Validate the 
+      - name: Validate model catalog JSON schema
+        uses: dsanders11/json-schema-validate-action
+        with:
+          schema: json-schema
+          files: schema/model-catalog.schema.json
+
+      - name: Test the model catalog JSON schema
+        uses: dsanders11/json-schema-validate-action
+        with:
+          schema: schema/model-catalog.schema.json
+          files: schema/tests/*.json

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -42,13 +42,13 @@ jobs:
 
       # Validate the 
       - name: Validate model catalog JSON schema
-        uses: dsanders11/json-schema-validate-action
+        uses: dsanders11/json-schema-validate-action@v1.2.0
         with:
           schema: json-schema
           files: schema/model-catalog.schema.json
 
       - name: Test the model catalog JSON schema
-        uses: dsanders11/json-schema-validate-action
+        uses: dsanders11/json-schema-validate-action@v1.2.0
         with:
           schema: schema/model-catalog.schema.json
           files: schema/tests/*.json

--- a/schema/README.md
+++ b/schema/README.md
@@ -3,15 +3,17 @@
 The goal of the [model catalog schema](./model-catalog.schema.json) is to provide a way to aggregate metadata for models and model servers into a consistent format that can be used to generate Backstage model catalog entities that represent them.
 
 ## Catalog Structure:
-- Represent each model server as a `Component` (of type `model-server`)
-- Each deployed model-server `Component` "dependsOn"
+In this catalog: 
+- Each model server is represented as a `Component` with type `model-server`, containing information such as:
+   - Name, description URL, authentication status, and how to get access
+- Each model deployed on a model server is represented as a `Resource` with type `ai-model`, containing information such as:
+   - Name, description, model usage, intended tasks, tags, license, and author
+- An `API` object representing the model server API type (of type `openai`, `grpc`, `graphql`, or `asyncapi`)
+- Each `model-server` Component `dependsOn`:
+   - The 1 to N `ai-model` resources deployed on it
+   - The `API` object associated with the model server
 
-    - 1 to N `Resources` representing the models deployed on the service (of type `ai-model`)
-    - `API` representing the model server API type (of type `openai`, `grpc`, `graphql`, `asyncapi`)
-- Techdocs:
-
-    - Techdoc for the `Component` referencing how to access the server
-    - Techdoc for each model `Resource` providing information about the model, and any model-specific usage or restrictions
+![AI Catalog](https://github.com/redhat-ai-dev/model-catalog-example/blob/main/assets/catalog-graph.png?raw=true "AI Catalog")
 
 A reference model catalog schema can be found [here](https://github.com/redhat-ai-dev/model-catalog-example/blob/main/developer-model-service/catalog-info.yaml)
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,17 @@
+# Model Catalog Schema
+
+The goal of the [model catalog schema](./model-catalog.schema.json) is to provide a way to aggregate metadata for models and model servers into a consistent format that can be used to generate Backstage model catalog entities that represent them.
+
+## Catalog Structure:
+- Represent each model service as a `Component`
+- Each deployed "model-server" `Component` dependsOn
+
+    - 1 to N `Resources` representing the models deployed on the service
+    - `API` representing the model server API type (e.g. OpenAI, OpenVINO, etc)
+- Techdocs:
+
+    - Techdoc for the `Component` referencing how to access the server
+    - Techdoc for each model `Resource` providing information about the model, and any model-specific usage or restrictions
+
+A reference model catalog schema can be found [here](https://github.com/redhat-ai-dev/model-catalog-example/blob/main/developer-model-service/catalog-info.yaml)
+

--- a/schema/README.md
+++ b/schema/README.md
@@ -3,11 +3,11 @@
 The goal of the [model catalog schema](./model-catalog.schema.json) is to provide a way to aggregate metadata for models and model servers into a consistent format that can be used to generate Backstage model catalog entities that represent them.
 
 ## Catalog Structure:
-- Represent each model service as a `Component`
-- Each deployed "model-server" `Component` dependsOn
+- Represent each model server as a `Component` (of type `model-server`)
+- Each deployed model-server `Component` "dependsOn"
 
-    - 1 to N `Resources` representing the models deployed on the service
-    - `API` representing the model server API type (e.g. OpenAI, OpenVINO, etc)
+    - 1 to N `Resources` representing the models deployed on the service (of type `ai-model`)
+    - `API` representing the model server API type (of type `openai`, `grpc`, `graphql`, `asyncapi`)
 - Techdocs:
 
     - Techdoc for the `Component` referencing how to access the server

--- a/schema/README.md
+++ b/schema/README.md
@@ -8,7 +8,7 @@ In this catalog:
    - Name, description URL, authentication status, and how to get access
 - Each model deployed on a model server is represented as a `Resource` with type `ai-model`, containing information such as:
    - Name, description, model usage, intended tasks, tags, license, and author
-- An `API` object representing the model server API type (of type `openai`, `grpc`, `graphql`, or `asyncapi`)
+- An `API` object representing the model server API type (of type `openai`, `grpc`, `graphql`, or `asyncapi`), which may include the API specification, and additional information about the model server's API.
 - Each `model-server` Component `dependsOn`:
    - The 1 to N `ai-model` resources deployed on it
    - The `API` object associated with the model server

--- a/schema/README.md
+++ b/schema/README.md
@@ -2,8 +2,17 @@
 
 The goal of the [model catalog schema](./model-catalog.schema.json) is to provide a way to aggregate metadata for models and model servers into a consistent format that can be used to generate Backstage model catalog entities that represent them.
 
-## Catalog Structure:
-In this catalog: 
+The schema can currently be used to map metadata to the Backstage catalog from the following scenarios:
+
+1) A Model/inference server deployed with one or more models, and an exposed API
+    - With both `modelServer` and `models` specified using the schema
+2) A standalone model, without a server or API exposing it
+    - With only `models` specified using the schema
+
+See below for how the metadata maps into Backstage catalog entities
+
+## Model Catalog Structure:
+In the Backstage Model Catalog: 
 - Each model server is represented as a `Component` with type `model-server`, containing information such as:
    - Name, description URL, authentication status, and how to get access
 - Each model deployed on a model server is represented as a `Resource` with type `ai-model`, containing information such as:

--- a/schema/model-catalog.schema.json
+++ b/schema/model-catalog.schema.json
@@ -1,0 +1,133 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Model Catalog",
+    "description": "Schema for defining model and model servers for conversion to Backstage catalog entities",
+    "type": "object",
+    "properties": {
+        "modelServer": {
+            "description": "A deployed model server running one or more models, exposed over an API",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the model server",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "The URL to access the model server",
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "The Backstage user that will be responsible for the model server",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of the model server and what it's for",
+                    "type": "string"
+                },
+                "usage": {
+                    "description": "How to use and interact with the model server",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Descriptive tags for the model server",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "apiURL": {
+                    "description": "The URL that the model server's API is exposed over",
+                    "type": "string"
+                },
+                "apiType": {
+                    "description": "The type of API that the model server exposes",
+                    "type": "string",
+                    "enum": ["openapi", "asyncapi", "graphql", "grpc"]
+                },
+                "apiSpec": {
+                    "description": "The schema used by the model server API",
+                    "type": "string"
+                },
+                "apiTags": {
+                    "description": "Descriptive tags for the model server's API",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "lifecycle": {
+                    "description": "The lifecycle state of the model server API",
+                    "type": "string"
+                },
+                "authentication": {
+                    "description": "Whether or not the model server requires authentication to access",
+                    "type": "boolean"
+                }
+            },
+            "required": ["name", "url", "owner", "description"]
+        },
+        "models": {
+            "description": "An array of AI models to be imported into the Backstage catalog",
+            "type": "array",
+            "items": {
+                "description": "An AI model to be imported into the Backstage catalog",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "The name of the model",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "The URL to access the model",
+                        "type": "string"
+                    },
+                    "owner": {
+                        "description": "The Backstage user that will be responsible for the model",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "A description of the model and what it's for",
+                        "type": "string"
+                    },
+                    "usage": {
+                        "description": "How to use and interact with the model",
+                        "type": "string"
+                    },
+                    "tags": {
+                        "description": "Descriptive tags for the model",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "resourceURL": {
+                        "description": "A URL to access the model's resources",
+                        "type": "string"
+                    },
+                    "apiURL": {
+                        "description": "The URL that the model server's API is exposed over",
+                        "type": "string"
+                    },
+                    "support": {
+                        "description": "Support information for the model / where to open issues",
+                        "type": "string"
+                    },
+                    "training": {
+                        "description": "Information on how the model was trained",
+                        "type": "string"
+                    },
+                    "ethics": {
+                        "description": "Any ethical considerations for the model",
+                        "type": "string"
+                    },
+                    "lifecycle": {
+                        "description": "The lifecycle state of the model server API",
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "url", "owner", "description"]
+            }
+            
+        }
+    }
+}

--- a/schema/model-catalog.schema.json
+++ b/schema/model-catalog.schema.json
@@ -77,10 +77,6 @@
                         "description": "The name of the model",
                         "type": "string"
                     },
-                    "url": {
-                        "description": "The URL to access the model",
-                        "type": "string"
-                    },
                     "owner": {
                         "description": "The Backstage user that will be responsible for the model",
                         "type": "string"

--- a/schema/model-catalog.schema.json
+++ b/schema/model-catalog.schema.json
@@ -12,8 +12,8 @@
                     "description": "The name of the model server",
                     "type": "string"
                 },
-                "url": {
-                    "description": "The URL to access the model server",
+                "homepageURL": {
+                    "description": "The URL for the model server's homepage, if present",
                     "type": "string"
                 },
                 "owner": {
@@ -35,25 +35,32 @@
                         "type": "string"
                     }
                 },
-                "apiURL": {
-                    "description": "The URL that the model server's API is exposed over",
-                    "type": "string"
-                },
-                "apiType": {
-                    "description": "The type of API that the model server exposes",
-                    "type": "string",
-                    "enum": ["openapi", "asyncapi", "graphql", "grpc"]
-                },
-                "apiSpec": {
-                    "description": "The schema used by the model server API",
-                    "type": "string"
-                },
-                "apiTags": {
-                    "description": "Descriptive tags for the model server's API",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "API": {
+                    "type": "object",
+                    "description": "The API metadata associated with the model server",
+                    "properties": {
+                        "url": {
+                            "description": "The URL that the model server's REST API is exposed over, how the model(s) are interacted with",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "The type of API that the model server exposes",
+                            "type": "string",
+                            "enum": ["openapi", "asyncapi", "graphql", "grpc"]
+                        },
+                        "spec": {
+                            "description": "A link to the schema used by the model server API",
+                            "type": "string"
+                        },
+                        "tags": {
+                            "description": "Descriptive tags for the model server's API",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": ["url", "type", "spec"]
                 },
                 "lifecycle": {
                     "description": "The lifecycle state of the model server API",
@@ -64,7 +71,7 @@
                     "type": "boolean"
                 }
             },
-            "required": ["name", "url", "owner", "description"]
+            "required": ["name", "owner", "lifecycle", "description"]
         },
         "models": {
             "description": "An array of AI models to be imported into the Backstage catalog",
@@ -96,12 +103,12 @@
                             "type": "string"
                         }
                     },
-                    "resourceURL": {
-                        "description": "A URL to access the model's resources",
+                    "artifactLocationURL": {
+                        "description": "A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc",
                         "type": "string"
                     },
-                    "apiURL": {
-                        "description": "The URL that the model server's API is exposed over",
+                    "howToUseURL": {
+                        "description": "The URL pointing to any specific documentation on how to use the model on the model server",
                         "type": "string"
                     },
                     "support": {
@@ -121,9 +128,17 @@
                         "type": "string"
                     }
                 },
-                "required": ["name", "url", "owner", "description"]
+                "required": ["name", "owner", "description", "lifecycle"]
             }
             
+        }   
+    },
+    "anyOf": [
+        {
+            "required": ["models"]
+        },
+        {
+            "required": ["modelSever", "models"]
         }
-    }
+    ]
 }

--- a/schema/tests/001-min-values.json
+++ b/schema/tests/001-min-values.json
@@ -1,15 +1,21 @@
 {
-    "modelServer": {
-      "name": "developer-model-service",
-      "url": "https://example.com",
-      "owner": "example-user",
-      "description": "Developer model service running on vLLM"
+  "modelServer": {
+    "name": "developer-model-service",
+    "owner": "example-user",
+    "description": "Developer model service running on vLLM",
+    "API": {
+      "url": "https://api.example.com",
+      "type": "openapi",
+      "spec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json"
     },
-    "model": [
-      {
-        "name": "ibm-granite-20b",
-        "description": "IBM Granite 20b model running on vLLM",
-        "owner": "example-user"
-      }
-    ]
-  }
+    "lifecycle": "production"
+  },
+  "models": [
+    {
+      "name": "ibm-granite-20b",
+      "description": "IBM Granite 20b model running on vLLM",
+      "owner": "example-user",
+      "lifecycle": "production"
+    }
+  ]
+}

--- a/schema/tests/001-min-values.json
+++ b/schema/tests/001-min-values.json
@@ -9,7 +9,6 @@
       {
         "name": "ibm-granite-20b",
         "description": "IBM Granite 20b model running on vLLM",
-        "url": "https://example.com/granite",
         "owner": "example-user"
       }
     ]

--- a/schema/tests/001-min-values.json
+++ b/schema/tests/001-min-values.json
@@ -1,0 +1,16 @@
+{
+    "modelServer": {
+      "name": "developer-model-service",
+      "url": "https://example.com",
+      "owner": "example-user",
+      "description": "Developer model service running on vLLM"
+    },
+    "model": [
+      {
+        "name": "ibm-granite-20b",
+        "description": "IBM Granite 20b model running on vLLM",
+        "url": "https://example.com/granite",
+        "owner": "example-user"
+      }
+    ]
+  }

--- a/schema/tests/002-non-techdocs.json
+++ b/schema/tests/002-non-techdocs.json
@@ -1,0 +1,25 @@
+{
+    "modelServer": {
+      "name": "developer-model-service",
+      "url": "https://example.com",
+      "owner": "example-user",
+      "description": "Developer model service running on vLLM",
+      "usage": "Model server usage description",
+      "tags": ["vLLM", "granite", "ibm"],
+      "apiURL": "https://api.example.com",
+      "apiType": "openapi",
+      "apiSpec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+      "authentication": true,
+      "apiTags": ["openapi", "openai", "3scale"]
+    },
+    "model": [
+      {
+        "name": "ibm-granite-20b",
+        "description": "IBM Granite 20b model running on vLLM",
+        "url": "https://example.com/granite",
+        "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+        "tags": ["IBM", "granite", "vllm", "20b"],
+        "owner": "example-user"
+      }
+    ]
+  }

--- a/schema/tests/002-non-techdocs.json
+++ b/schema/tests/002-non-techdocs.json
@@ -1,24 +1,29 @@
 {
     "modelServer": {
       "name": "developer-model-service",
-      "url": "https://example.com",
       "owner": "example-user",
       "description": "Developer model service running on vLLM",
+      "homepageURL": "https://model-service.apps.example.com",
       "usage": "Model server usage description",
       "tags": ["vLLM", "granite", "ibm"],
-      "apiURL": "https://api.example.com",
-      "apiType": "openapi",
-      "apiSpec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
-      "authentication": true,
-      "apiTags": ["openapi", "openai", "3scale"]
+      "API": {
+        "url": "https://api.model-service.apps.example.com",
+        "type": "openapi",
+        "spec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+        "tags": ["openapi", "openai", "3scale"]
+      },
+      "lifecycle": "production",
+      "authentication": true
     },
-    "model": [
+    "models": [
       {
         "name": "ibm-granite-20b",
         "description": "IBM Granite 20b model running on vLLM",
-        "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+        "artifactLocationURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+        "howToUseURL": "https://model-service.apps.example.com/docs",
         "tags": ["IBM", "granite", "vllm", "20b"],
-        "owner": "example-user"
+        "owner": "example-user",
+        "lifecycle": "production"
       }
     ]
   }

--- a/schema/tests/002-non-techdocs.json
+++ b/schema/tests/002-non-techdocs.json
@@ -16,7 +16,6 @@
       {
         "name": "ibm-granite-20b",
         "description": "IBM Granite 20b model running on vLLM",
-        "url": "https://example.com/granite",
         "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
         "tags": ["IBM", "granite", "vllm", "20b"],
         "owner": "example-user"

--- a/schema/tests/003-multiple-models.json
+++ b/schema/tests/003-multiple-models.json
@@ -16,7 +16,6 @@
       {
         "name": "ibm-granite-20b",
         "description": "IBM Granite 20b model running on vLLM",
-        "url": "https://example.com/granite",
         "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
         "tags": ["IBM", "granite", "vllm", "20b"],
         "owner": "example-user"
@@ -24,7 +23,6 @@
       {
         "name": "mistral-7b",
         "description": "Mistral 7b model running on vLLM",
-        "url": "https://example.com/mistral",
         "resourceURL": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
         "tags": ["mistralai", "mistral", "vllm", "7b"],
         "owner": "example-user"
@@ -32,7 +30,6 @@
       {
         "name": "gemma-2-2b",
         "description": "Google Gemma 2 2b model running on vLLM",
-        "url": "https://example.com/gemma",
         "resourceURL": "https://huggingface.co/google/gemma-2-2b",
         "tags": ["google", "gemma"],
         "owner": "example-user"

--- a/schema/tests/003-multiple-models.json
+++ b/schema/tests/003-multiple-models.json
@@ -6,33 +6,39 @@
       "description": "Developer model service running on vLLM",
       "usage": "Model server usage description",
       "tags": ["vLLM", "granite", "ibm"],
-      "apiURL": "https://api.example.com",
-      "apiType": "openapi",
-      "apiSpec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
-      "authentication": true,
-      "apiTags": ["openapi", "openai", "3scale"]
+      "API": {
+        "url": "https://api.example.com",
+        "type": "openapi",
+        "spec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+        "tags": ["openapi", "openai", "3scale"]
+      },
+      "lifecycle": "production",
+      "authentication": true
     },
-    "model": [
+    "models": [
       {
         "name": "ibm-granite-20b",
         "description": "IBM Granite 20b model running on vLLM",
-        "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+        "artifactLocationURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
         "tags": ["IBM", "granite", "vllm", "20b"],
-        "owner": "example-user"
+        "owner": "example-user",
+        "lifecycle": "production"
       },
       {
         "name": "mistral-7b",
         "description": "Mistral 7b model running on vLLM",
-        "resourceURL": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
+        "artifactLocationURL": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
         "tags": ["mistralai", "mistral", "vllm", "7b"],
-        "owner": "example-user"
+        "owner": "example-user",
+        "lifecycle": "production"
       },
       {
         "name": "gemma-2-2b",
         "description": "Google Gemma 2 2b model running on vLLM",
-        "resourceURL": "https://huggingface.co/google/gemma-2-2b",
+        "artifactLocationURL": "https://huggingface.co/google/gemma-2-2b",
         "tags": ["google", "gemma"],
-        "owner": "example-user"
+        "owner": "example-user",
+        "lifecycle": "production"
       }
     ]
   }

--- a/schema/tests/003-multiple-models.json
+++ b/schema/tests/003-multiple-models.json
@@ -1,0 +1,41 @@
+{
+    "modelServer": {
+      "name": "developer-model-service",
+      "url": "https://example.com",
+      "owner": "example-user",
+      "description": "Developer model service running on vLLM",
+      "usage": "Model server usage description",
+      "tags": ["vLLM", "granite", "ibm"],
+      "apiURL": "https://api.example.com",
+      "apiType": "openapi",
+      "apiSpec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+      "authentication": true,
+      "apiTags": ["openapi", "openai", "3scale"]
+    },
+    "model": [
+      {
+        "name": "ibm-granite-20b",
+        "description": "IBM Granite 20b model running on vLLM",
+        "url": "https://example.com/granite",
+        "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+        "tags": ["IBM", "granite", "vllm", "20b"],
+        "owner": "example-user"
+      },
+      {
+        "name": "mistral-7b",
+        "description": "Mistral 7b model running on vLLM",
+        "url": "https://example.com/mistral",
+        "resourceURL": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
+        "tags": ["mistralai", "mistral", "vllm", "7b"],
+        "owner": "example-user"
+      },
+      {
+        "name": "gemma-2-2b",
+        "description": "Google Gemma 2 2b model running on vLLM",
+        "url": "https://example.com/gemma",
+        "resourceURL": "https://huggingface.co/google/gemma-2-2b",
+        "tags": ["google", "gemma"],
+        "owner": "example-user"
+      }
+    ]
+  }

--- a/schema/tests/004-longer-strings.json
+++ b/schema/tests/004-longer-strings.json
@@ -16,7 +16,6 @@
     {
       "name": "ibm-granite-20b",
       "description": "Granite-8B-Code-Instruct-4K is a 8B parameter model fine-tuned from Granite-8B-Code-Base-4K on a combination of permissively licensed instruction data to enhance instruction following capabilities including logical reasoning and problem-solving skills.",
-      "url": "https://example.com/granite",
       "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
       "tags": ["IBM", "granite", "vllm", "20b"],
       "owner": "example-user",

--- a/schema/tests/004-longer-strings.json
+++ b/schema/tests/004-longer-strings.json
@@ -6,19 +6,24 @@
     "description": "Developer model service running on vLLM",
     "usage": "Model server usage description",
     "tags": ["vLLM", "granite", "ibm"],
-    "apiURL": "https://api.example.com",
-    "apiType": "openapi",
-    "apiSpec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+    "API": {
+      "url": "https://api.example.com",
+      "type": "openapi",
+      "spec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+      "tags": ["openapi", "openai", "3scale"]
+    },
+    "lifecycle": "production",
     "authentication": true,
     "apiTags": ["openapi", "openai", "3scale"]
   },
-  "model": [
+  "models": [
     {
       "name": "ibm-granite-20b",
       "description": "Granite-8B-Code-Instruct-4K is a 8B parameter model fine-tuned from Granite-8B-Code-Base-4K on a combination of permissively licensed instruction data to enhance instruction following capabilities including logical reasoning and problem-solving skills.",
-      "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+      "artifactLocationURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
       "tags": ["IBM", "granite", "vllm", "20b"],
       "owner": "example-user",
+      "lifecycle": "production",
       "support": "string",
       "training": "The Granite Code Instruct models were trained on the following data types:\n- **Code Commits Datasets:** we sourced code commits data from the [CommitPackFT](https://huggingface.co/datasets/bigcode/commitpackft) dataset, a filtered version of the full CommitPack dataset. From CommitPackFT dataset, we only consider data for 92 programming languages. Our inclusion criteria boils down to selecting programming languages common across CommitPackFT and the 116 languages that we considered to pretrain the code-base model (*Granite-8B-Code-Base*).\n- **Math Datasets:** We consider two high-quality math datasets, [MathInstruct](https://huggingface.co/datasets/TIGER-Lab/MathInstruct) and [MetaMathQA](https://huggingface.co/datasets/meta-math/MetaMathQA). Due to license issues, we filtered out GSM8K-RFT and Camel-Math from MathInstruct dataset.\n- **Code Instruction Datasets:** We use [Glaive-Code-Assistant-v3](https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v3), [Glaive-Function-Calling-v2](https://huggingface.co/datasets/glaiveai/glaive-function-calling-v2), [NL2SQL11](https://huggingface.co/datasets/bugdaryan/sql-create-context-instruction) and a small collection of synthetic API calling datasets.\n- **Language Instruction Datasets:** We include high-quality datasets such as [HelpSteer](https://huggingface.co/datasets/nvidia/HelpSteer) and an open license-filtered version of [Platypus](https://huggingface.co/datasets/garage-bAInd/Open-Platypus). We also include a collection of hardcoded prompts to ensure our model generates correct outputs given inquiries about its name or developers.",
       "usage": "This is a simple example of how to use Granite-8B-Code-Instruct-4K model.\n\n```python\nimport torch\nfrom transformers import AutoModelForCausalLM, AutoTokenizer\ndevice = \"cuda\" # or \"cpu\"\nmodel_path = \"ibm-granite/granite-8b-code-instruct-4k\"\ntokenizer = AutoTokenizer.from_pretrained(model_path)\n# drop device_map if running on CPU\nmodel = AutoModelForCausalLM.from_pretrained(model_path, device_map=device)\nmodel.eval()\n# change input text as desired\nchat = [\n    { \"role\": \"user\", \"content\": \"Write a code to find the maximum value in a list of numbers.\" },\n]\nchat = tokenizer.apply_chat_template(chat, tokenize=False, add_generation_prompt=True)\n# tokenize the text\ninput_tokens = tokenizer(chat, return_tensors=\"pt\")\n# transfer tokenized inputs to the device\nfor i in input_tokens:\n    input_tokens[i] = input_tokens[i].to(device)\n# generate output tokens\noutput = model.generate(**input_tokens, max_new_tokens=100)\n# decode output tokens into text\noutput = tokenizer.batch_decode(output)\n# loop over the batch to print, in this example the batch size is 1\nfor i in output:\n    print(i)\n```\n*[Code Reference](https://huggingface.co/ibm-granite/granite-8b-code-instruct-4k#generation)*",

--- a/schema/tests/004-longer-strings.json
+++ b/schema/tests/004-longer-strings.json
@@ -1,0 +1,29 @@
+{
+  "modelServer": {
+    "name": "developer-model-service",
+    "url": "https://example.com",
+    "owner": "example-user",
+    "description": "Developer model service running on vLLM",
+    "usage": "Model server usage description",
+    "tags": ["vLLM", "granite", "ibm"],
+    "apiURL": "https://api.example.com",
+    "apiType": "openapi",
+    "apiSpec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+    "authentication": true,
+    "apiTags": ["openapi", "openai", "3scale"]
+  },
+  "model": [
+    {
+      "name": "ibm-granite-20b",
+      "description": "Granite-8B-Code-Instruct-4K is a 8B parameter model fine-tuned from Granite-8B-Code-Base-4K on a combination of permissively licensed instruction data to enhance instruction following capabilities including logical reasoning and problem-solving skills.",
+      "url": "https://example.com/granite",
+      "resourceURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+      "tags": ["IBM", "granite", "vllm", "20b"],
+      "owner": "example-user",
+      "support": "string",
+      "training": "The Granite Code Instruct models were trained on the following data types:\n- **Code Commits Datasets:** we sourced code commits data from the [CommitPackFT](https://huggingface.co/datasets/bigcode/commitpackft) dataset, a filtered version of the full CommitPack dataset. From CommitPackFT dataset, we only consider data for 92 programming languages. Our inclusion criteria boils down to selecting programming languages common across CommitPackFT and the 116 languages that we considered to pretrain the code-base model (*Granite-8B-Code-Base*).\n- **Math Datasets:** We consider two high-quality math datasets, [MathInstruct](https://huggingface.co/datasets/TIGER-Lab/MathInstruct) and [MetaMathQA](https://huggingface.co/datasets/meta-math/MetaMathQA). Due to license issues, we filtered out GSM8K-RFT and Camel-Math from MathInstruct dataset.\n- **Code Instruction Datasets:** We use [Glaive-Code-Assistant-v3](https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v3), [Glaive-Function-Calling-v2](https://huggingface.co/datasets/glaiveai/glaive-function-calling-v2), [NL2SQL11](https://huggingface.co/datasets/bugdaryan/sql-create-context-instruction) and a small collection of synthetic API calling datasets.\n- **Language Instruction Datasets:** We include high-quality datasets such as [HelpSteer](https://huggingface.co/datasets/nvidia/HelpSteer) and an open license-filtered version of [Platypus](https://huggingface.co/datasets/garage-bAInd/Open-Platypus). We also include a collection of hardcoded prompts to ensure our model generates correct outputs given inquiries about its name or developers.",
+      "usage": "This is a simple example of how to use Granite-8B-Code-Instruct-4K model.\n\n```python\nimport torch\nfrom transformers import AutoModelForCausalLM, AutoTokenizer\ndevice = \"cuda\" # or \"cpu\"\nmodel_path = \"ibm-granite/granite-8b-code-instruct-4k\"\ntokenizer = AutoTokenizer.from_pretrained(model_path)\n# drop device_map if running on CPU\nmodel = AutoModelForCausalLM.from_pretrained(model_path, device_map=device)\nmodel.eval()\n# change input text as desired\nchat = [\n    { \"role\": \"user\", \"content\": \"Write a code to find the maximum value in a list of numbers.\" },\n]\nchat = tokenizer.apply_chat_template(chat, tokenize=False, add_generation_prompt=True)\n# tokenize the text\ninput_tokens = tokenizer(chat, return_tensors=\"pt\")\n# transfer tokenized inputs to the device\nfor i in input_tokens:\n    input_tokens[i] = input_tokens[i].to(device)\n# generate output tokens\noutput = model.generate(**input_tokens, max_new_tokens=100)\n# decode output tokens into text\noutput = tokenizer.batch_decode(output)\n# loop over the batch to print, in this example the batch size is 1\nfor i in output:\n    print(i)\n```\n*[Code Reference](https://huggingface.co/ibm-granite/granite-8b-code-instruct-4k#generation)*",
+      "ethics": "Granite Code Instruct models are primarily fine-tuned using instruction-response pairs across a specific set of programming languages. Thus, their performance may be limited with out-of-domain programming languages. In this situation, it is beneficial providing few-shot examples to steer the model's output. Moreover, developers should perform safety testing and target-specific tuning before deploying these models on critical applications. The model also inherits ethical considerations and limitations from its base model. For more information, please refer to [Granite-8B-Code-Base-4K model card](https://huggingface.co/ibm-granite/granite-8b-code-base-4k)."
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHDHPAI-608

- Implements a basic JSON schema that can be used by the RHDH catalog plugin to generate model catalog entities.
   - Adapted from the [RHDH Model Catalog Software Template doc](https://docs.google.com/document/d/1PeQwnqVrwZ75GJoJbBiDqCukMADMCpbZbSY49XbjjhA/edit?tab=t.0), which in turn was adapted from our [Implementing Model Catalog in Backstage Doc](https://docs.google.com/document/d/1ArB8w-TawZ_DuMbZoukk4inVsAgqHntB8yN2lttwjyo/edit)
   - I've opted to include the techdoc specific entries (e.g. usage examples, and training information), but that may / may not be used. 
- Basic tests that provides some validation of the JSON schema

