### PR TITLE
[RHDHPAI-609] Re-organize JSON schema, and add typescript and go type generation

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Generate types, and ensure latest changes were committed
         run: |
+          make install-quicktype
           make generate-types-all
           if [[ ! -z $(git status -s) ]]
           then

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -40,13 +40,14 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      # Validate the 
+      # Validate the JSON schemas
       - name: Validate model catalog JSON schema
         uses: dsanders11/json-schema-validate-action@v1.2.0
         with:
           schema: json-schema
           files: schema/model-catalog.schema.json
 
+      # Run tests against the schema
       - name: Test the model catalog JSON schema
         uses: dsanders11/json-schema-validate-action@v1.2.0
         with:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -53,3 +53,13 @@ jobs:
         with:
           schema: schema/model-catalog.schema.json
           files: schema/tests/*.json
+
+      - name: Generate types, and ensure latest changes were committed
+        run: |
+          make generate-types-all
+          if [[ ! -z $(git status -s) ]]
+          then
+            echo 'Command `make generate-types-all` did introduce changes, which should not be the case if it had been run as part of the PR. Please run it locally and check in the results as part of your PR.'
+            git --no-pager diff
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,12 @@ test-unit:
 install-quicktype:
 	npm install -g quicktype
 
-generate-schema-all: generate-schema-typescript generate-schema-golang
+generate-types-all: generate-typescript generate-golang
 
 # Requires quicktype to be installed before running
 # Run 'make install-quicktype' first if it's not installed
-generate-schema-typescript:
+generate-typescript:
 	cd schema/types/typescript; yarn generate
 
-generate-schema-golang:
+generate-golang:
 	cd schema; sed 's|\#/$$defs/modelServerAPI|\#/$$defs/modelServer/$$defs/modelServerAPI|g' model-catalog.schema.json | quicktype -s schema -o types/golang/model-catalog.go --package golang

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,15 @@ test: test-unit
 test-unit:
 	go test $(GO_FLAGS) $(GO_TEST_FLAGS) ./cmd/... ./pkg/...
 
+install-quicktype:
+	npm install -g quicktype
+
+generate-schema-all: generate-schema-typescript generate-schema-golang
+
+# Requires quicktype to be installed before running
+# Run 'make install-quicktype' first if it's not installed
+generate-schema-typescript:
+	cd schema/types/typescript; yarn generate
+
+generate-schema-golang:
+	cd schema; sed 's|\#/$$defs/modelServerAPI|\#/$$defs/modelServer/$$defs/modelServerAPI|g' model-catalog.schema.json | quicktype -s schema -o types/golang/model-catalog.go --package golang

--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ Either via the command line, or from your favorite Golang editor, set the follow
 ### Debugging (VS Code)
 
 To debug the bridge services in VS Code, a launch.json file has been provided with options to debug each of the individual services. Ensure that you launch VS Code from the same terminal window that has the above environment variables set.
+
+## Model Catalog Schema
+
+The schema that the model catalog bridge will use to collect model and model server metadata can be found under [schema/](./schema/).
+
+To re-generate the types that correspond to the schema, run `make generate-types-all`.

--- a/schema/README.md
+++ b/schema/README.md
@@ -5,7 +5,8 @@ The goal of the [model catalog schema](./model-catalog.schema.json) is to provid
 The schema can currently be used to map metadata to the Backstage catalog from the following scenarios:
 
 1) A Model/inference server deployed with one or more models, and an exposed API
-    - With both `modelServer` and `models` specified using the schema
+    - With `modelServer` and `modelServerAPI` defining the model server and API metadata
+    - With `model` defining the model metadata
 2) A standalone model, without a server or API exposing it
     - With only `models` specified using the schema
 
@@ -25,4 +26,3 @@ In the Backstage Model Catalog:
 ![AI Catalog](https://github.com/redhat-ai-dev/model-catalog-example/blob/main/assets/catalog-graph.png?raw=true "AI Catalog")
 
 A reference model catalog schema can be found [here](https://github.com/redhat-ai-dev/model-catalog-example/blob/main/developer-model-service/catalog-info.yaml)
-

--- a/schema/model-catalog.schema.json
+++ b/schema/model-catalog.schema.json
@@ -1,199 +1,199 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Model Catalog",
-  "description": "Schema for defining AI models and model servers, for conversion to Backstage catalog entities",
-  "type": "object",
-  "anyOf": [
-    {
-      "required": [
-        "models"
-      ]
-    },
-    {
-      "required": [
-        "modelSever",
-        "models"
-      ]
-    }
-  ],
-  "properties": {
-    "modelServer": {
-      "description": "A deployed model server running one or more models, exposed over an API",
-      "$ref": "#/$defs/modelServer",
-      "type": "object"
-    },
-    "models": {
-      "description": "An array of AI models to be imported into the Backstage catalog",
-      "type": "array",
-      "items": {
-        "description": "An AI model to be imported into the Backstage catalog",
-        "$ref": "#/$defs/model",
-        "type": "object"
-      }
-    }
-  },
-  "additionalProperties": false,
-  "$defs": {
-    "modelServer": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "modelServer",
-      "title": "Model Server",
-      "description": "Schema for defining AI model servers, for conversion to Backstage catalog entities",
-      "type": "object",
-      "required": [
-        "name",
-        "owner",
-        "lifecycle",
-        "description"
-      ],
-      "properties": {
-        "description": {
-          "description": "A description of the model server and what it's for",
-          "type": "string"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Model Catalog",
+    "description": "Schema for defining AI models and model servers, for conversion to Backstage catalog entities",
+    "type": "object",
+    "anyOf": [
+        {
+            "required": [
+                "models"
+            ]
         },
-        "API": {
-          "description": "The API metadata associated with the model server",
-          "$ref": "#/$defs/modelServerAPI",
-          "type": "object"
-        },
-        "authentication": {
-          "description": "Whether or not the model server requires authentication to access",
-          "type": "boolean"
-        },
-        "homepageURL": {
-          "description": "The URL for the model server's homepage, if present",
-          "type": "string"
-        },
-        "lifecycle": {
-          "description": "The lifecycle state of the model server API",
-          "type": "string"
-        },
-        "name": {
-          "description": "The name of the model server",
-          "type": "string"
-        },
-        "owner": {
-          "description": "The Backstage user that will be responsible for the model server",
-          "type": "string"
-        },
-        "tags": {
-          "description": "Descriptive tags for the model server",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "usage": {
-          "description": "How to use and interact with the model server",
-          "type": "string"
+        {
+            "required": [
+                "modelSever",
+                "models"
+            ]
         }
-      },
-      "additionalProperties": false,
-      "$defs": {
-        "modelServerAPI": {
-          "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "$id": "modelServerAPI",
-          "title": "Model Server API",
-          "description": "Schema for defining the API exposed by model servers, for conversion to Backstage catalog entities",
-          "type": "object",
-          "required": [
-            "url",
-            "type",
-            "spec"
-          ],
-          "properties": {
-            "type": {
-              "description": "The type of API that the model server exposes",
-              "type": "string",
-              "enum": [
-                "openapi",
-                "asyncapi",
-                "graphql",
-                "grpc"
-              ]
-            },
-            "spec": {
-              "description": "A link to the schema used by the model server API",
-              "type": "string"
-            },
-            "tags": {
-              "description": "Descriptive tags for the model server's API",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "url": {
-              "description": "The URL that the model server's REST API is exposed over, how the model(s) are interacted with",
-              "type": "string"
+    ],
+    "properties": {
+        "modelServer": {
+            "description": "A deployed model server running one or more models, exposed over an API",
+            "$ref": "#/$defs/modelServer",
+            "type": "object"
+        },
+        "models": {
+            "description": "An array of AI models to be imported into the Backstage catalog",
+            "type": "array",
+            "items": {
+                "description": "An AI model to be imported into the Backstage catalog",
+                "$ref": "#/$defs/model",
+                "type": "object"
             }
-          },
-          "additionalProperties": false
         }
-      }
     },
-    "model": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "model",
-      "title": "Model",
-      "description": "Schema for defining AI models conversion to Backstage catalog entities",
-      "type": "object",
-      "required": [
-        "name",
-        "owner",
-        "description",
-        "lifecycle"
-      ],
-      "properties": {
-        "description": {
-          "description": "A description of the model and what it's for",
-          "type": "string"
+    "additionalProperties": false,
+    "$defs": {
+        "modelServer": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "modelServer",
+            "title": "Model Server",
+            "description": "Schema for defining AI model servers, for conversion to Backstage catalog entities",
+            "type": "object",
+            "required": [
+                "name",
+                "owner",
+                "lifecycle",
+                "description"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A description of the model server and what it's for",
+                    "type": "string"
+                },
+                "API": {
+                    "description": "The API metadata associated with the model server",
+                    "$ref": "#/$defs/modelServerAPI",
+                    "type": "object"
+                },
+                "authentication": {
+                    "description": "Whether or not the model server requires authentication to access",
+                    "type": "boolean"
+                },
+                "homepageURL": {
+                    "description": "The URL for the model server's homepage, if present",
+                    "type": "string"
+                },
+                "lifecycle": {
+                    "description": "The lifecycle state of the model server API",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the model server",
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "The Backstage user that will be responsible for the model server",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Descriptive tags for the model server",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "usage": {
+                    "description": "How to use and interact with the model server",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "$defs": {
+                "modelServerAPI": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "modelServerAPI",
+                    "title": "Model Server API",
+                    "description": "Schema for defining the API exposed by model servers, for conversion to Backstage catalog entities",
+                    "type": "object",
+                    "required": [
+                        "url",
+                        "type",
+                        "spec"
+                    ],
+                    "properties": {
+                        "type": {
+                            "description": "The type of API that the model server exposes",
+                            "type": "string",
+                            "enum": [
+                                "openapi",
+                                "asyncapi",
+                                "graphql",
+                                "grpc"
+                            ]
+                        },
+                        "spec": {
+                            "description": "A link to the schema used by the model server API",
+                            "type": "string"
+                        },
+                        "tags": {
+                            "description": "Descriptive tags for the model server's API",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "url": {
+                            "description": "The URL that the model server's REST API is exposed over, how the model(s) are interacted with",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
         },
-        "artifactLocationURL": {
-          "description": "A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc",
-          "type": "string"
-        },
-        "ethics": {
-          "description": "Any ethical considerations for the model",
-          "type": "string"
-        },
-        "howToUseURL": {
-          "description": "The URL pointing to any specific documentation on how to use the model on the model server",
-          "type": "string"
-        },
-        "lifecycle": {
-          "description": "The lifecycle state of the model server API",
-          "type": "string"
-        },
-        "name": {
-          "description": "The name of the model",
-          "type": "string"
-        },
-        "owner": {
-          "description": "The Backstage user that will be responsible for the model",
-          "type": "string"
-        },
-        "support": {
-          "description": "Support information for the model / where to open issues",
-          "type": "string"
-        },
-        "tags": {
-          "description": "Descriptive tags for the model",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "training": {
-          "description": "Information on how the model was trained",
-          "type": "string"
-        },
-        "usage": {
-          "description": "How to use and interact with the model",
-          "type": "string"
+        "model": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "model",
+            "title": "Model",
+            "description": "Schema for defining AI models conversion to Backstage catalog entities",
+            "type": "object",
+            "required": [
+                "name",
+                "owner",
+                "description",
+                "lifecycle"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A description of the model and what it's for",
+                    "type": "string"
+                },
+                "artifactLocationURL": {
+                    "description": "A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc",
+                    "type": "string"
+                },
+                "ethics": {
+                    "description": "Any ethical considerations for the model",
+                    "type": "string"
+                },
+                "howToUseURL": {
+                    "description": "The URL pointing to any specific documentation on how to use the model on the model server",
+                    "type": "string"
+                },
+                "lifecycle": {
+                    "description": "The lifecycle state of the model server API",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the model",
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "The Backstage user that will be responsible for the model",
+                    "type": "string"
+                },
+                "support": {
+                    "description": "Support information for the model / where to open issues",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Descriptive tags for the model",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "training": {
+                    "description": "Information on how the model was trained",
+                    "type": "string"
+                },
+                "usage": {
+                    "description": "How to use and interact with the model",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
         }
-      },
-      "additionalProperties": false
     }
-  }
 }

--- a/schema/model-catalog.schema.json
+++ b/schema/model-catalog.schema.json
@@ -1,144 +1,199 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "Model Catalog",
-    "description": "Schema for defining model and model servers for conversion to Backstage catalog entities",
-    "type": "object",
-    "properties": {
-        "modelServer": {
-            "description": "A deployed model server running one or more models, exposed over an API",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "description": "The name of the model server",
-                    "type": "string"
-                },
-                "homepageURL": {
-                    "description": "The URL for the model server's homepage, if present",
-                    "type": "string"
-                },
-                "owner": {
-                    "description": "The Backstage user that will be responsible for the model server",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "A description of the model server and what it's for",
-                    "type": "string"
-                },
-                "usage": {
-                    "description": "How to use and interact with the model server",
-                    "type": "string"
-                },
-                "tags": {
-                    "description": "Descriptive tags for the model server",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "API": {
-                    "type": "object",
-                    "description": "The API metadata associated with the model server",
-                    "properties": {
-                        "url": {
-                            "description": "The URL that the model server's REST API is exposed over, how the model(s) are interacted with",
-                            "type": "string"
-                        },
-                        "type": {
-                            "description": "The type of API that the model server exposes",
-                            "type": "string",
-                            "enum": ["openapi", "asyncapi", "graphql", "grpc"]
-                        },
-                        "spec": {
-                            "description": "A link to the schema used by the model server API",
-                            "type": "string"
-                        },
-                        "tags": {
-                            "description": "Descriptive tags for the model server's API",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "required": ["url", "type", "spec"]
-                },
-                "lifecycle": {
-                    "description": "The lifecycle state of the model server API",
-                    "type": "string"
-                },
-                "authentication": {
-                    "description": "Whether or not the model server requires authentication to access",
-                    "type": "boolean"
-                }
-            },
-            "required": ["name", "owner", "lifecycle", "description"]
-        },
-        "models": {
-            "description": "An array of AI models to be imported into the Backstage catalog",
-            "type": "array",
-            "items": {
-                "description": "An AI model to be imported into the Backstage catalog",
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "description": "The name of the model",
-                        "type": "string"
-                    },
-                    "owner": {
-                        "description": "The Backstage user that will be responsible for the model",
-                        "type": "string"
-                    },
-                    "description": {
-                        "description": "A description of the model and what it's for",
-                        "type": "string"
-                    },
-                    "usage": {
-                        "description": "How to use and interact with the model",
-                        "type": "string"
-                    },
-                    "tags": {
-                        "description": "Descriptive tags for the model",
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "artifactLocationURL": {
-                        "description": "A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc",
-                        "type": "string"
-                    },
-                    "howToUseURL": {
-                        "description": "The URL pointing to any specific documentation on how to use the model on the model server",
-                        "type": "string"
-                    },
-                    "support": {
-                        "description": "Support information for the model / where to open issues",
-                        "type": "string"
-                    },
-                    "training": {
-                        "description": "Information on how the model was trained",
-                        "type": "string"
-                    },
-                    "ethics": {
-                        "description": "Any ethical considerations for the model",
-                        "type": "string"
-                    },
-                    "lifecycle": {
-                        "description": "The lifecycle state of the model server API",
-                        "type": "string"
-                    }
-                },
-                "required": ["name", "owner", "description", "lifecycle"]
-            }
-            
-        }   
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Model Catalog",
+  "description": "Schema for defining AI models and model servers, for conversion to Backstage catalog entities",
+  "type": "object",
+  "anyOf": [
+    {
+      "required": [
+        "models"
+      ]
     },
-    "anyOf": [
-        {
-            "required": ["models"]
+    {
+      "required": [
+        "modelSever",
+        "models"
+      ]
+    }
+  ],
+  "properties": {
+    "modelServer": {
+      "description": "A deployed model server running one or more models, exposed over an API",
+      "$ref": "#/$defs/modelServer",
+      "type": "object"
+    },
+    "models": {
+      "description": "An array of AI models to be imported into the Backstage catalog",
+      "type": "array",
+      "items": {
+        "description": "An AI model to be imported into the Backstage catalog",
+        "$ref": "#/$defs/model",
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "modelServer": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "modelServer",
+      "title": "Model Server",
+      "description": "Schema for defining AI model servers, for conversion to Backstage catalog entities",
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "lifecycle",
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "description": "A description of the model server and what it's for",
+          "type": "string"
         },
-        {
-            "required": ["modelSever", "models"]
+        "API": {
+          "description": "The API metadata associated with the model server",
+          "$ref": "#/$defs/modelServerAPI",
+          "type": "object"
+        },
+        "authentication": {
+          "description": "Whether or not the model server requires authentication to access",
+          "type": "boolean"
+        },
+        "homepageURL": {
+          "description": "The URL for the model server's homepage, if present",
+          "type": "string"
+        },
+        "lifecycle": {
+          "description": "The lifecycle state of the model server API",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the model server",
+          "type": "string"
+        },
+        "owner": {
+          "description": "The Backstage user that will be responsible for the model server",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Descriptive tags for the model server",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "usage": {
+          "description": "How to use and interact with the model server",
+          "type": "string"
         }
-    ]
+      },
+      "additionalProperties": false,
+      "$defs": {
+        "modelServerAPI": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "modelServerAPI",
+          "title": "Model Server API",
+          "description": "Schema for defining the API exposed by model servers, for conversion to Backstage catalog entities",
+          "type": "object",
+          "required": [
+            "url",
+            "type",
+            "spec"
+          ],
+          "properties": {
+            "type": {
+              "description": "The type of API that the model server exposes",
+              "type": "string",
+              "enum": [
+                "openapi",
+                "asyncapi",
+                "graphql",
+                "grpc"
+              ]
+            },
+            "spec": {
+              "description": "A link to the schema used by the model server API",
+              "type": "string"
+            },
+            "tags": {
+              "description": "Descriptive tags for the model server's API",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "url": {
+              "description": "The URL that the model server's REST API is exposed over, how the model(s) are interacted with",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "model": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "model",
+      "title": "Model",
+      "description": "Schema for defining AI models conversion to Backstage catalog entities",
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "description",
+        "lifecycle"
+      ],
+      "properties": {
+        "description": {
+          "description": "A description of the model and what it's for",
+          "type": "string"
+        },
+        "artifactLocationURL": {
+          "description": "A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc",
+          "type": "string"
+        },
+        "ethics": {
+          "description": "Any ethical considerations for the model",
+          "type": "string"
+        },
+        "howToUseURL": {
+          "description": "The URL pointing to any specific documentation on how to use the model on the model server",
+          "type": "string"
+        },
+        "lifecycle": {
+          "description": "The lifecycle state of the model server API",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the model",
+          "type": "string"
+        },
+        "owner": {
+          "description": "The Backstage user that will be responsible for the model",
+          "type": "string"
+        },
+        "support": {
+          "description": "Support information for the model / where to open issues",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Descriptive tags for the model",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "training": {
+          "description": "Information on how the model was trained",
+          "type": "string"
+        },
+        "usage": {
+          "description": "How to use and interact with the model",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/schema/tests/003-multiple-models.json
+++ b/schema/tests/003-multiple-models.json
@@ -1,7 +1,6 @@
 {
     "modelServer": {
       "name": "developer-model-service",
-      "url": "https://example.com",
       "owner": "example-user",
       "description": "Developer model service running on vLLM",
       "usage": "Model server usage description",

--- a/schema/tests/004-longer-strings.json
+++ b/schema/tests/004-longer-strings.json
@@ -1,7 +1,6 @@
 {
   "modelServer": {
     "name": "developer-model-service",
-    "url": "https://example.com",
     "owner": "example-user",
     "description": "Developer model service running on vLLM",
     "usage": "Model server usage description",
@@ -13,8 +12,7 @@
       "tags": ["openapi", "openai", "3scale"]
     },
     "lifecycle": "production",
-    "authentication": true,
-    "apiTags": ["openapi", "openai", "3scale"]
+    "authentication": true
   },
   "models": [
     {

--- a/schema/types/golang/README.md
+++ b/schema/types/golang/README.md
@@ -1,0 +1,16 @@
+# model-catalog
+
+This Golang type definition is automatically generated from the [model catalog schema](../model-catalog-schema.json) using [quicktype](https://github.com/glideapps/quicktype).
+
+## Updating 
+
+If you are making changes to the schema and need to re-generate the types, run `make generate-schema-golang` from the root of the repository. 
+
+## Type Generation
+
+The command that `make generate-schema-golang` runs to generate the types is 
+```
+cd schema; sed 's|\#/$$defs/modelServerAPI|\#/$$defs/modelServer/$$defs/modelServerAPI|g' model-catalog.schema.json | quicktype -s schema -o types/golang/model-catalog.go --package golang
+```
+
+**Note:** Due to implementation differences between different JSON Schema parsers, some parsers treat references against nested names as relative references, and others absolute. Quicktype requires absolute references, which is why we must use `sed` to change our reference to `modelServerAPI` from relative to absolute.

--- a/schema/types/golang/model-catalog.go
+++ b/schema/types/golang/model-catalog.go
@@ -1,0 +1,106 @@
+// This file was generated from JSON Schema using quicktype, do not modify it directly.
+// To parse and unparse this JSON data, add this code to your project and do:
+//
+//    modelCatalog, err := UnmarshalModelCatalog(bytes)
+//    bytes, err = modelCatalog.Marshal()
+
+package golang
+
+import "encoding/json"
+
+func UnmarshalModelCatalog(data []byte) (ModelCatalog, error) {
+	var r ModelCatalog
+	err := json.Unmarshal(data, &r)
+	return r, err
+}
+
+func (r *ModelCatalog) Marshal() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+// Schema for defining AI models and model servers, for conversion to Backstage catalog
+// entities
+type ModelCatalog struct {
+	// An array of AI models to be imported into the Backstage catalog                     
+	Models                                                                    []Model      `json:"models"`
+	// A deployed model server running one or more models, exposed over an API             
+	ModelServer                                                               *ModelServer `json:"modelServer,omitempty"`
+}
+
+// A deployed model server running one or more models, exposed over an API
+//
+// Schema for defining AI model servers, for conversion to Backstage catalog entities
+type ModelServer struct {
+	// The API metadata associated with the model server                         
+	API                                                                 *API     `json:"API,omitempty"`
+	// Whether or not the model server requires authentication to access         
+	Authentication                                                      *bool    `json:"authentication,omitempty"`
+	// A description of the model server and what it's for                       
+	Description                                                         string   `json:"description"`
+	// The URL for the model server's homepage, if present                       
+	HomepageURL                                                         *string  `json:"homepageURL,omitempty"`
+	// The lifecycle state of the model server API                               
+	Lifecycle                                                           string   `json:"lifecycle"`
+	// The name of the model server                                              
+	Name                                                                string   `json:"name"`
+	// The Backstage user that will be responsible for the model server          
+	Owner                                                               string   `json:"owner"`
+	// Descriptive tags for the model server                                     
+	Tags                                                                []string `json:"tags,omitempty"`
+	// How to use and interact with the model server                             
+	Usage                                                               *string  `json:"usage,omitempty"`
+}
+
+// The API metadata associated with the model server
+//
+// Schema for defining the API exposed by model servers, for conversion to Backstage catalog
+// entities
+type API struct {
+	// A link to the schema used by the model server API                                                 
+	Spec                                                                                        string   `json:"spec"`
+	// Descriptive tags for the model server's API                                                       
+	Tags                                                                                        []string `json:"tags,omitempty"`
+	// The type of API that the model server exposes                                                     
+	Type                                                                                        Type     `json:"type"`
+	// The URL that the model server's REST API is exposed over, how the model(s) are interacted         
+	// with                                                                                              
+	URL                                                                                         string   `json:"url"`
+}
+
+// An AI model to be imported into the Backstage catalog
+//
+// Schema for defining AI models conversion to Backstage catalog entities
+type Model struct {
+	// A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc                     
+	ArtifactLocationURL                                                                          *string  `json:"artifactLocationURL,omitempty"`
+	// A description of the model and what it's for                                                       
+	Description                                                                                  string   `json:"description"`
+	// Any ethical considerations for the model                                                           
+	Ethics                                                                                       *string  `json:"ethics,omitempty"`
+	// The URL pointing to any specific documentation on how to use the model on the model server         
+	HowToUseURL                                                                                  *string  `json:"howToUseURL,omitempty"`
+	// The lifecycle state of the model server API                                                        
+	Lifecycle                                                                                    string   `json:"lifecycle"`
+	// The name of the model                                                                              
+	Name                                                                                         string   `json:"name"`
+	// The Backstage user that will be responsible for the model                                          
+	Owner                                                                                        string   `json:"owner"`
+	// Support information for the model / where to open issues                                           
+	Support                                                                                      *string  `json:"support,omitempty"`
+	// Descriptive tags for the model                                                                     
+	Tags                                                                                         []string `json:"tags,omitempty"`
+	// Information on how the model was trained                                                           
+	Training                                                                                     *string  `json:"training,omitempty"`
+	// How to use and interact with the model                                                             
+	Usage                                                                                        *string  `json:"usage,omitempty"`
+}
+
+// The type of API that the model server exposes
+type Type string
+
+const (
+	Asyncapi Type = "asyncapi"
+	Graphql  Type = "graphql"
+	Grpc     Type = "grpc"
+	Openapi  Type = "openapi"
+)

--- a/schema/types/typescript/README.md
+++ b/schema/types/typescript/README.md
@@ -1,0 +1,16 @@
+# model-catalog
+
+This Typescript type definition is automatically generated from the [model catalog schema](../model-catalog-schema.json) using [quicktype](https://github.com/glideapps/quicktype).
+
+## Updating 
+
+If you are making changes to the schema and need to re-generate the types, run `yarn generate`. 
+
+## Type Generation
+
+The command that `yarn generate` runs to generate the types is 
+```
+sed 's|#/$defs/modelServerAPI|#/$defs/modelServer/$defs/modelServerAPI|g' model-catalog.schema.json | quicktype -s schema -o model-catalog.d.ts --just-types
+```
+
+**Note:** Due to implementation differences between different JSON Schema parsers, some parsers treat references against nested names as relative references, and others absolute. Quicktype requires absolute references, which is why we must use `sed` to change our reference to `modelServerAPI` from relative to absolute.

--- a/schema/types/typescript/index.d.ts
+++ b/schema/types/typescript/index.d.ts
@@ -1,0 +1,146 @@
+/**
+ * Schema for defining AI models and model servers, for conversion to Backstage catalog
+ * entities
+ */
+export interface ModelCatalog {
+    /**
+     * An array of AI models to be imported into the Backstage catalog
+     */
+    models: Model[];
+    /**
+     * A deployed model server running one or more models, exposed over an API
+     */
+    modelServer?: ModelServer;
+}
+
+/**
+ * A deployed model server running one or more models, exposed over an API
+ *
+ * Schema for defining AI model servers, for conversion to Backstage catalog entities
+ */
+export interface ModelServer {
+    /**
+     * The API metadata associated with the model server
+     */
+    API?: API;
+    /**
+     * Whether or not the model server requires authentication to access
+     */
+    authentication?: boolean;
+    /**
+     * A description of the model server and what it's for
+     */
+    description: string;
+    /**
+     * The URL for the model server's homepage, if present
+     */
+    homepageURL?: string;
+    /**
+     * The lifecycle state of the model server API
+     */
+    lifecycle: string;
+    /**
+     * The name of the model server
+     */
+    name: string;
+    /**
+     * The Backstage user that will be responsible for the model server
+     */
+    owner: string;
+    /**
+     * Descriptive tags for the model server
+     */
+    tags?: string[];
+    /**
+     * How to use and interact with the model server
+     */
+    usage?: string;
+}
+
+/**
+ * The API metadata associated with the model server
+ *
+ * Schema for defining the API exposed by model servers, for conversion to Backstage catalog
+ * entities
+ */
+export interface API {
+    /**
+     * A link to the schema used by the model server API
+     */
+    spec: string;
+    /**
+     * Descriptive tags for the model server's API
+     */
+    tags?: string[];
+    /**
+     * The type of API that the model server exposes
+     */
+    type: Type;
+    /**
+     * The URL that the model server's REST API is exposed over, how the model(s) are interacted
+     * with
+     */
+    url: string;
+}
+
+/**
+ * The type of API that the model server exposes
+ */
+export enum Type {
+    Asyncapi = "asyncapi",
+    Graphql = "graphql",
+    Grpc = "grpc",
+    Openapi = "openapi",
+}
+
+/**
+ * An AI model to be imported into the Backstage catalog
+ *
+ * Schema for defining AI models conversion to Backstage catalog entities
+ */
+export interface Model {
+    /**
+     * A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc
+     */
+    artifactLocationURL?: string;
+    /**
+     * A description of the model and what it's for
+     */
+    description: string;
+    /**
+     * Any ethical considerations for the model
+     */
+    ethics?: string;
+    /**
+     * The URL pointing to any specific documentation on how to use the model on the model server
+     */
+    howToUseURL?: string;
+    /**
+     * The lifecycle state of the model server API
+     */
+    lifecycle: string;
+    /**
+     * The name of the model
+     */
+    name: string;
+    /**
+     * The Backstage user that will be responsible for the model
+     */
+    owner: string;
+    /**
+     * Support information for the model / where to open issues
+     */
+    support?: string;
+    /**
+     * Descriptive tags for the model
+     */
+    tags?: string[];
+    /**
+     * Information on how the model was trained
+     */
+    training?: string;
+    /**
+     * How to use and interact with the model
+     */
+    usage?: string;
+}

--- a/schema/types/typescript/package.json
+++ b/schema/types/typescript/package.json
@@ -1,0 +1,20 @@
+{
+    "private": true,
+    "name": "@redhat-ai-dev/model-catalog-types",
+    "version": "1.0.0",
+    "scripts": {
+        "generate": "sed 's|#/$defs/modelServerAPI|#/$defs/modelServer/$defs/modelServerAPI|g' ../../model-catalog.schema.json | quicktype -s schema -o index.d.ts --just-types --top-level ModelCatalog"
+      },
+    "projects": [
+        "https://github.com/redhat-ai-dev/model-catalog-bridge/"
+    ],
+    "devDependencies": {
+        "@redhat-ai-dev/model-catalog-types": "workspace:."
+    },
+    "owners": [
+        {
+            "name": "John Collier",
+            "githubUsername": "johnmcollier"
+        }
+    ]
+}

--- a/schema/types/typescript/tsconfig.json
+++ b/schema/types/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}


### PR DESCRIPTION
While working on the Typescript type conversion for the Model Catalog Schema, I found that I needed to define each sub component of the schema (`model`, `modelServer` and `modelServer.API`) as a separate schema, to allow for Typescript types to be generated for each. 

While not strictly necessary for the type conversion, this does make interacting with the schema somewhat cleaner. 