### PR TITLE
RHDHPAI-647: on startup bootstrap location service with models present in the storage service

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Either via the command line, or from your favorite Golang editor, set the follow
 
 ### location
 
-1. None of the above env vars are needed at this time.
+1. `STORAGE_URL` is the same as above
 
 When you are ready to launch the 3 processes, set your current namespace to the `NAMESPACE` value:
 

--- a/cmd/location/main.go
+++ b/cmd/location/main.go
@@ -4,51 +4,16 @@ import (
 	goflag "flag"
 	gin_gonic_http_srv "github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/server/location/server"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/util"
-	"io/fs"
 	"k8s.io/klog/v2"
 	"os"
-	"path/filepath"
-	"strings"
 )
 
 func main() {
 	flagset := goflag.NewFlagSet("location", goflag.ContinueOnError)
 	klog.InitFlags(flagset)
 
-	//TODO remove and most likely employ some sort of fetch from the storage layer
-	content := map[string]*gin_gonic_http_srv.ImportLocation{}
-	err := filepath.Walk("/data", func(path string, info fs.FileInfo, err error) error {
-		if info == nil {
-			return nil
-		}
-		if strings.Contains(info.Name(), "_") {
-			c := []byte{}
-			klog.Infoln("processing configmap file " + info.Name())
-			if info.IsDir() {
-				return nil
-			}
-			if strings.HasPrefix(info.Name(), "..") {
-				klog.Infof("skipping file starting with ..: %s", info.Name())
-			}
-			fullName := "/data/" + info.Name()
-			klog.Infof("reading file %s", fullName)
-			c, err = os.ReadFile(fullName)
-			if err != nil {
-				klog.Errorf("%s", err.Error())
-				klog.Flush()
-				return err
-			}
-			klog.Infof("adding file %s with content len %d to list", info.Name(), len(c))
-			ic := &gin_gonic_http_srv.ImportLocation{}
-			content[info.Name()] = ic
-		}
-		return nil
-	})
-	if err != nil {
-		klog.Errorf("%s", err.Error())
-		os.Exit(-1)
-	}
-	server := gin_gonic_http_srv.NewImportLocationServer(content)
+	st := os.Getenv("STORAGE_URL")
+	server := gin_gonic_http_srv.NewImportLocationServer(st)
 	stopCh := util.SetupSignalHandler()
 	server.Run(stopCh)
 

--- a/pkg/cmd/cli/backstage/locations.go
+++ b/pkg/cmd/cli/backstage/locations.go
@@ -19,7 +19,7 @@ func (b *BackstageRESTClientWrapper) ListLocations() (string, error) {
 	return buffer.String(), err
 }
 
-func (b *BackstageRESTClientWrapper) GetLocation(args ...string) (string, error) {
+func (b *BackstageRESTClientWrapper) GetLocations(args ...string) (string, error) {
 	if len(args) == 0 {
 		return b.ListLocations()
 	}
@@ -34,6 +34,16 @@ func (b *BackstageRESTClientWrapper) GetLocation(args ...string) (string, error)
 		buffer.WriteString("\n")
 	}
 	return buffer.String(), nil
+}
+
+func (b *BackstageRESTClientWrapper) GetLocation(id string) (map[string]any, error) {
+	url := b.RootURL + rest.LOCATION_URI + "/" + id
+	resp, err := backstageRESTClient.RESTClient.R().SetAuthToken(b.Token).SetHeader("Accept", "application/json").Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return b.processUpdate(resp, "get", url, "")
+
 }
 
 func (b *BackstageRESTClientWrapper) ImportLocation(url string) (map[string]any, error) {

--- a/pkg/cmd/cli/backstage/locations_test.go
+++ b/pkg/cmd/cli/backstage/locations_test.go
@@ -1,6 +1,7 @@
 package backstage
 
 import (
+	"fmt"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/backstage"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
 	"testing"
@@ -20,12 +21,37 @@ func TestGetLocations(t *testing.T) {
 	defer ts.Close()
 
 	key := "key1"
-	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetLocation(key)
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetLocations(key)
 	common.AssertError(t, err)
 	common.AssertContains(t, str, []string{key})
 }
 
+func TestGetLocation(t *testing.T) {
+	ts := backstage.CreateServer(t)
+	defer ts.Close()
+
+	key := "TestGet"
+	m, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetLocation(key)
+	common.AssertError(t, err)
+	keysStr := ""
+	for k := range m {
+		keysStr = fmt.Sprintf("%s;%s", keysStr, k)
+	}
+	common.AssertContains(t, keysStr, []string{key})
+}
+
 func TestGetLocationsError(t *testing.T) {
+	ts := backstage.CreateServer(t)
+	defer ts.Close()
+
+	nsName := "404:404"
+	_, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetLocations(nsName)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestGetLocationError(t *testing.T) {
 	ts := backstage.CreateServer(t)
 	defer ts.Close()
 

--- a/pkg/cmd/server/location/server/server_test.go
+++ b/pkg/cmd/server/location/server/server_test.go
@@ -6,13 +6,43 @@ import (
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
 	testgin "github.com/redhat-ai-dev/model-catalog-bridge/test/stub/gin-gonic"
+	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/storage"
 	"io"
 	"k8s.io/apimachinery/pkg/util/json"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 )
+
+func TestLoadFromStorage(t *testing.T) {
+	callback := &sync.Map{}
+	st := storage.CreateBridgeStorageREST(t, callback)
+	defer st.Close()
+	testWriter := testgin.NewTestResponseWriter()
+	ctx, eng := gin.CreateTestContext(testWriter)
+	ils := &ImportLocationServer{
+		router:  eng,
+		content: map[string]*ImportLocation{},
+		storage: storage.SetupBridgeStorageRESTClient(st),
+	}
+
+	done, err := ils.loadFromStorage()
+
+	common.AssertError(t, err)
+	common.AssertEqual(t, true, done)
+	common.AssertEqual(t, http.StatusOK, ctx.Writer.Status())
+
+	called := false
+	callback.Range(func(key, value any) bool {
+		called = true
+		return true
+	})
+	common.AssertEqual(t, true, called)
+	bodyBuf := testWriter.ResponseWriter.Body
+	common.AssertNotNil(t, bodyBuf)
+}
 
 func TestHandleCatalogDiscoveryGet(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/cmd/server/rhoai-normalizer/controller_test.go
+++ b/pkg/cmd/server/rhoai-normalizer/controller_test.go
@@ -34,7 +34,7 @@ func TestReconcile(t *testing.T) {
 	brts := location.CreateBridgeLocationServer(t)
 	defer brts.Close()
 	callback := sync.Map{}
-	bsts := storage.CreateBridgeStorageRESTClient(t, &callback)
+	bsts := storage.CreateBridgeStorageREST(t, &callback)
 	defer bsts.Close()
 
 	r := &RHOAINormalizerReconcile{
@@ -133,7 +133,7 @@ func TestStart(t *testing.T) {
 	brts := location.CreateBridgeLocationServer(t)
 	defer brts.Close()
 	callback := sync.Map{}
-	bsts := storage.CreateBridgeStorageRESTClient(t, &callback)
+	bsts := storage.CreateBridgeStorageREST(t, &callback)
 	defer bsts.Close()
 
 	r := &RHOAINormalizerReconcile{
@@ -219,7 +219,7 @@ func TestStartArchived(t *testing.T) {
 	brts := location.CreateBridgeLocationServer(t)
 	defer brts.Close()
 	callback := sync.Map{}
-	bsts := storage.CreateBridgeStorageRESTClient(t, &callback)
+	bsts := storage.CreateBridgeStorageREST(t, &callback)
 	defer bsts.Close()
 
 	r := &RHOAINormalizerReconcile{

--- a/pkg/rest/backstage.go
+++ b/pkg/rest/backstage.go
@@ -16,6 +16,7 @@ const (
 type BackstageImport interface {
 	ImportLocation(url string) (map[string]any, error)
 	DeleteLocation(id string) (string, error)
+	GetLocation(id string) (map[string]any, error)
 }
 
 func ParseImportLocationMap(retJSON map[string]any) (id string, target string, ok bool) {

--- a/pkg/types/storage.go
+++ b/pkg/types/storage.go
@@ -11,9 +11,10 @@ type BridgeStorage interface {
 }
 
 type StorageBody struct {
-	Body           []byte `json:"body"`
-	LocationId     string `json:"locationId"`
-	LocationTarget string `json:"locationTarget"`
+	Body            []byte `json:"body"`
+	LocationId      string `json:"locationId"`
+	LocationTarget  string `json:"locationTarget"`
+	LocationIDValid bool   `json:"locationIDValid"`
 }
 
 type BridgeStorageType string

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,12 +1,14 @@
 package util
 
 const (
-	DefaultOwner         = "rhdh-rhoai-bridge"
-	DefaultLifecycle     = "development"
-	StorageConfigMapName = "bac-import-model"
-	KeyQueryParam        = "key"
-	UpsertURI            = "/upsert"
-	CurrentKeySetURI     = "/currentkeyset"
-	RemoveURI            = "/remove"
-	ListURI              = "/list"
+	DefaultOwner          = "rhdh-rhoai-bridge"
+	DefaultLifecycle      = "development"
+	StorageConfigMapName  = "bac-import-model"
+	KeyQueryParam         = "key"
+	UpsertURI             = "/upsert"
+	CurrentKeySetURI      = "/currentkeyset"
+	RemoveURI             = "/remove"
+	ListURI               = "/list"
+	FetchURI              = "/fetch"
+	BackgroundStoragePoll = "/backgroundstoragepoll"
 )

--- a/test/stub/storage/storage.go
+++ b/test/stub/storage/storage.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/server/storage"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/util"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -16,16 +19,40 @@ import (
 func SetupBridgeStorageRESTClient(ts *httptest.Server) *storage.BridgeStorageRESTClient {
 	storageTC := &storage.BridgeStorageRESTClient{}
 	storageTC.RESTClient = common.DC()
-	storageTC.UpsertURL = ts.URL
+	storageTC.UpsertURL = ts.URL + util.UpsertURI
+	storageTC.ListURL = ts.URL + util.ListURI
+	storageTC.FetchURL = ts.URL + util.FetchURI
 	return storageTC
 }
 
-func CreateBridgeStorageRESTClient(t *testing.T, called *sync.Map) *httptest.Server {
+func CreateBridgeStorageREST(t *testing.T, called *sync.Map) *httptest.Server {
 	ts := common.CreateTestServer(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("Method: %v", r.Method)
 		t.Logf("Path: %v", r.URL.Path)
 
 		switch r.Method {
+		case common.MethodGet:
+			switch {
+			case strings.Contains(r.URL.Path, util.ListURI):
+				called.Store(util.ListURI, util.ListURI)
+				w.Header().Set("Content-Type", "application/json")
+				d := &storage.DiscoverResponse{Keys: []string{"foo_bar"}}
+				buf, _ := json.Marshal(d)
+				w.Write(buf)
+				w.WriteHeader(http.StatusOK)
+			case strings.Contains(r.URL.Path, util.FetchURI):
+				called.Store(util.FetchURI, util.FetchURI)
+				w.Header().Set("Content-Type", "application/json")
+				sb := types.StorageBody{
+					Body:            []byte{},
+					LocationId:      "foo-id",
+					LocationTarget:  "http://foo.io",
+					LocationIDValid: false,
+				}
+				buf, _ := json.Marshal(&sb)
+				w.Write(buf)
+				w.WriteHeader(http.StatusOK)
+			}
 		case common.MethodPost:
 			switch r.URL.Path {
 			default:


### PR DESCRIPTION
this change also revealed the need for some fixes in maintaining the location service's in memory cache

tested by 
- registering then deploying the registered model in ODH KFMR
- start up the normalizer and storage containers
- see the configmap get updated with the normalized content
- start up the location container
- curl'ed the location container for list models and get model
- start up backstage and see data imported (either push or pull)