### PR TITLE
RHDHPAI-640: meets min, local dev, level of dockerfiles

### DIFF
--- a/Dockerfile.rhoai-normalizer
+++ b/Dockerfile.rhoai-normalizer
@@ -9,12 +9,12 @@ COPY vendor/ vendor/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o location ./cmd/location/...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o rhoai-normalizer ./cmd/rhoai-normalizer/...
 
 FROM registry.access.redhat.com/ubi9-minimal:9.1.0
 
-COPY --from=builder /opt/app-root/src/location /usr/local/bin/location
+COPY --from=builder /opt/app-root/src/rhoai-normalizer /usr/local/bin/rhoai-normalizer
 
 USER 65532:65532
 
-ENTRYPOINT [ "location" ]
+ENTRYPOINT [ "rhoai-normalizer" ]

--- a/Dockerfile.storage-rest
+++ b/Dockerfile.storage-rest
@@ -8,13 +8,14 @@ COPY go.sum go.sum
 COPY vendor/ vendor/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
+COPY test/ test/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o location ./cmd/location/...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o storage-rest ./cmd/storage-rest/...
 
 FROM registry.access.redhat.com/ubi9-minimal:9.1.0
 
-COPY --from=builder /opt/app-root/src/location /usr/local/bin/location
+COPY --from=builder /opt/app-root/src/storage-rest /usr/local/bin/storage-rest
 
 USER 65532:65532
 
-ENTRYPOINT [ "location" ]
+ENTRYPOINT [ "storage-rest" ]

--- a/pkg/cmd/cli/backstage/apis_test.go
+++ b/pkg/cmd/cli/backstage/apis_test.go
@@ -11,7 +11,7 @@ func TestListAPIs(t *testing.T) {
 	defer ts.Close()
 
 	// Get with no args calls List
-	str, err := SetupBackstageTestRESTClient(ts).GetAPI()
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetAPI()
 
 	common.AssertError(t, err)
 	common.AssertLineCompare(t, str, common.Apis, 0)
@@ -22,7 +22,7 @@ func TestGetAPIs(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "default:ollama-service-api"
-	str, err := SetupBackstageTestRESTClient(ts).GetAPI(nsName)
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetAPI(nsName)
 
 	common.AssertError(t, err)
 	common.AssertContains(t, str, []string{nsName})
@@ -33,7 +33,7 @@ func TestGetAPIsError(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "404:404"
-	_, err := SetupBackstageTestRESTClient(ts).GetAPI(nsName)
+	_, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetAPI(nsName)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -43,7 +43,7 @@ func TestGetAPIsWithTags(t *testing.T) {
 	ts := backstage.CreateServer(t)
 	defer ts.Close()
 
-	bs := SetupBackstageTestRESTClient(ts)
+	bs := &BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}
 	bs.Tags = true
 
 	for _, tc := range []struct {

--- a/pkg/cmd/cli/backstage/components_test.go
+++ b/pkg/cmd/cli/backstage/components_test.go
@@ -11,7 +11,7 @@ func TestListComponents(t *testing.T) {
 	defer ts.Close()
 
 	// Get with no args calls List
-	str, err := SetupBackstageTestRESTClient(ts).GetComponent()
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetComponent()
 	common.AssertError(t, err)
 	common.AssertLineCompare(t, str, common.Components, 0)
 }
@@ -21,7 +21,7 @@ func TestGetComponents(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "default:ollama-service-component"
-	str, err := SetupBackstageTestRESTClient(ts).GetComponent(nsName)
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetComponent(nsName)
 
 	common.AssertError(t, err)
 	common.AssertContains(t, str, []string{nsName})
@@ -32,7 +32,7 @@ func TestGetComponentsError(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "404:404"
-	_, err := SetupBackstageTestRESTClient(ts).GetComponent(nsName)
+	_, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetComponent(nsName)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -42,7 +42,7 @@ func TestGetComponentsWithTags(t *testing.T) {
 	ts := backstage.CreateServer(t)
 	defer ts.Close()
 
-	bs := SetupBackstageTestRESTClient(ts)
+	bs := &BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}
 	bs.Tags = true
 
 	for _, tc := range []struct {

--- a/pkg/cmd/cli/backstage/entities_test.go
+++ b/pkg/cmd/cli/backstage/entities_test.go
@@ -10,7 +10,7 @@ func TestListEntities(t *testing.T) {
 	ts := backstage.CreateServer(t)
 	defer ts.Close()
 
-	str, err := SetupBackstageTestRESTClient(ts).ListEntities()
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).ListEntities()
 	common.AssertError(t, err)
 	common.AssertEqual(t, common.TestJSONStringIndented, str)
 }

--- a/pkg/cmd/cli/backstage/locations_test.go
+++ b/pkg/cmd/cli/backstage/locations_test.go
@@ -10,7 +10,7 @@ func TestListLocations(t *testing.T) {
 	ts := backstage.CreateServer(t)
 	defer ts.Close()
 
-	str, err := SetupBackstageTestRESTClient(ts).ListLocations()
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).ListLocations()
 	common.AssertError(t, err)
 	common.AssertEqual(t, common.TestJSONStringIndented, str)
 }
@@ -20,7 +20,7 @@ func TestGetLocations(t *testing.T) {
 	defer ts.Close()
 
 	key := "key1"
-	str, err := SetupBackstageTestRESTClient(ts).GetLocation(key)
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetLocation(key)
 	common.AssertError(t, err)
 	common.AssertContains(t, str, []string{key})
 }
@@ -30,7 +30,7 @@ func TestGetLocationsError(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "404:404"
-	_, err := SetupBackstageTestRESTClient(ts).GetLocation(nsName)
+	_, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetLocation(nsName)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -41,9 +41,9 @@ func TestImportLocation(t *testing.T) {
 	defer ts.Close()
 
 	arg := "http://rhoai-bridge.com/mnist/v1/catalog-info.yaml"
-	retJSON, err := SetupBackstageTestRESTClient(ts).ImportLocation(arg)
+	retJSON, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).ImportLocation(arg)
 	common.AssertError(t, err)
-	str, err := SetupBackstageTestRESTClient(ts).PrintImportLocation(retJSON)
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).PrintImportLocation(retJSON)
 	common.AssertError(t, err)
 	common.AssertContains(t, str, []string{arg})
 }
@@ -53,7 +53,7 @@ func TestImportLocationError(t *testing.T) {
 	defer ts.Close()
 
 	arg := ":"
-	_, err := SetupBackstageTestRESTClient(ts).ImportLocation(arg)
+	_, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).ImportLocation(arg)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -64,7 +64,7 @@ func TestDeleteLocation(t *testing.T) {
 	defer ts.Close()
 
 	arg := "my-location-id"
-	str, err := SetupBackstageTestRESTClient(ts).DeleteLocation(arg)
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).DeleteLocation(arg)
 	common.AssertError(t, err)
 	common.AssertContains(t, str, []string{arg})
 }
@@ -74,7 +74,7 @@ func TestDeleteLocationsError(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "404:404"
-	_, err := SetupBackstageTestRESTClient(ts).DeleteLocation(nsName)
+	_, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).DeleteLocation(nsName)
 	if err == nil {
 		t.Error("expected error")
 	}

--- a/pkg/cmd/cli/backstage/resources_test.go
+++ b/pkg/cmd/cli/backstage/resources_test.go
@@ -11,7 +11,7 @@ func TestListResources(t *testing.T) {
 	defer ts.Close()
 
 	// Get with no args calls List
-	str, err := SetupBackstageTestRESTClient(ts).GetResource()
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetResource()
 	common.AssertError(t, err)
 	common.AssertLineCompare(t, str, common.Resources, 0)
 }
@@ -21,7 +21,7 @@ func TestGetResources(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "default:phi-mini-instruct"
-	str, err := SetupBackstageTestRESTClient(ts).GetResource(nsName)
+	str, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetResource(nsName)
 
 	common.AssertError(t, err)
 	common.AssertContains(t, str, []string{nsName})
@@ -32,7 +32,7 @@ func TestGetResourceError(t *testing.T) {
 	defer ts.Close()
 
 	nsName := "404:404"
-	_, err := SetupBackstageTestRESTClient(ts).GetResource(nsName)
+	_, err := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL}).GetResource(nsName)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -42,7 +42,7 @@ func TestGetResourceWithTags(t *testing.T) {
 	ts := backstage.CreateServer(t)
 	defer ts.Close()
 
-	bs := SetupBackstageTestRESTClient(ts)
+	bs := (&BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: ts.URL})
 	bs.Tags = true
 
 	for _, tc := range []struct {

--- a/pkg/cmd/cli/backstage/rest.go
+++ b/pkg/cmd/cli/backstage/rest.go
@@ -7,9 +7,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
-	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
 	"k8s.io/klog/v2"
-	"net/http/httptest"
 	nurl "net/url"
 	"os"
 )
@@ -137,11 +135,4 @@ func (k *BackstageRESTClientWrapper) deleteFromBackstage(url string) (string, er
 		return "", err
 	}
 	return k.processDelete(resp, url, "delete")
-}
-
-func SetupBackstageTestRESTClient(ts *httptest.Server) *BackstageRESTClientWrapper {
-	backstageTestRESTClient := &BackstageRESTClientWrapper{}
-	backstageTestRESTClient.RESTClient = common.DC()
-	backstageTestRESTClient.RootURL = ts.URL
-	return backstageTestRESTClient
 }

--- a/pkg/cmd/server/storage/server_test.go
+++ b/pkg/cmd/server/storage/server_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/gin-gonic/gin"
-	bksgcli "github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/backstage"
+	bkstgclient "github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/backstage"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/server/storage/configmap"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
@@ -87,7 +87,7 @@ func Test_handleCatalogUpsertPost_handleCatalogCurrentKeySetPost_ConfigMap(t *te
 			mutex:           sync.Mutex{},
 			pushedLocations: map[string]*types.StorageBody{},
 			locations:       location.SetupBridgeLocationRESTClient(brts),
-			bkstg:           bksgcli.SetupBackstageTestRESTClient(bks),
+			bkstg:           (&bkstgclient.BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: bks.URL}),
 		}
 
 		s.handleCatalogUpsertPost(ctx)
@@ -170,7 +170,7 @@ func Test_handleCatalogUpsertPost_handleCatalogCurrentKeySetPost_ConfigMap(t *te
 		mutex:           sync.Mutex{},
 		pushedLocations: map[string]*types.StorageBody{},
 		locations:       location.SetupBridgeLocationRESTClient(brts),
-		bkstg:           bksgcli.SetupBackstageTestRESTClient(bks),
+		bkstg:           (&bkstgclient.BackstageRESTClientWrapper{RESTClient: common.DC(), RootURL: bks.URL}),
 	}
 
 	s.handleCatalogCurrentKeySetPost(ctx)


### PR DESCRIPTION
in setting up some local images for my testing of sidecard containers for RHDHPAI-698, I discovered that some of the test packages reworking had leaked enough into source code go files that while `make build` and `make test` works locally and from github actions, it did not work from container builds.

So this change introduces the dockerfiles and test code rework to allow for building

@johnmcollier as I understood from planning is going to attempt to take on a github action based push of images to quay.io/redhat-ai-dev for the 3 images as well with RHDHPAI-640 ... I'll leave that bit to him.  And he of course can move te container files / rename /etc. as he finds appropriate.

But this cleans things up from my earlier package reorg for tests when I originally forked this repo from the cli repo and introduced the initial offering of the location, rhoai-normalizer, and storage-rest containers 