### PR TITLE
[RHDHPAI-640] Add GitHub actions for building and publishing bridge container images

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,0 +1,57 @@
+name: Publish Container Images
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  publish-container-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+      - name: Build & Push - RHOAI Normalizer Container Image
+        uses: docker/build-push-action@v3
+        with:
+          dockerfile: Dockerfile.rhoai-normalizer
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+      - name: Location Service meta
+        id: meta-location
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            quay.io/redhat-ai-dev/model-catalog-location-service
+          tags: |
+            latest
+            type=sha
+      - name: Build & Push - Location Service Container Image
+        uses: docker/build-push-action@v3
+        with:
+          dockerfile: Dockerfile.location
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta-location.outputs.tags }}
+      - name: Storage Rest meta
+        id: meta-storage-rest
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            quay.io/redhat-ai-dev/model-catalog-storage-rest
+          tags: |
+            latest
+            type=sha
+      - name: Build & Push - Storage Rest Container Image
+        uses: docker/build-push-action@v3
+        with:
+          dockerfile: Dockerfile.storage-rest
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta-storage-rest.outputs.tags }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -64,3 +64,13 @@ jobs:
             git --no-pager diff
             exit 1
           fi
+
+  build-images:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Build Container Images
+        run: |
+          make build-containers

--- a/Dockerfile.location
+++ b/Dockerfile.location
@@ -1,5 +1,5 @@
 # go version here matches our go.mod
-FROM registry.redhat.io/rhel8/go-toolset:1.22.9 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
 
 WORKDIR /opt/app-root/src
 

--- a/Dockerfile.rhoai-normalizer
+++ b/Dockerfile.rhoai-normalizer
@@ -1,5 +1,5 @@
 # go version here matches our go.mod
-FROM registry.redhat.io/rhel8/go-toolset:1.22.9 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
 
 WORKDIR /opt/app-root/src
 

--- a/Dockerfile.storage-rest
+++ b/Dockerfile.storage-rest
@@ -1,5 +1,5 @@
 # go version here matches our go.mod
-FROM registry.redhat.io/rhel8/go-toolset:1.22.9 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
 
 WORKDIR /opt/app-root/src
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ INSTALL_LOCATION ?= /usr/local/bin
 
 ARGS ?=
 
+CONTAINER_ENGINE ?= podman
+LOCATION_SERVICE_IMAGE ?= quay.io/redhat-ai-dev/model-catalog-location-service
+LOCATION_SERVICE_TAG ?= latest
+RHOAI_NORMALIZER_IMAGE ?= quay.io/redhat-ai-dev/model-catalog-rhoai-normalizer
+RHOAI_NORMALIZER_TAG ?= latest
+STORAGE_REST_IMAGE ?= quay.io/redhat-ai-dev/model-catalog-storage-rest
+STORAGE_REST_TAG ?= latest
+
 .EXPORT_ALL_VARIABLES:
 
 
@@ -45,3 +53,14 @@ generate-typescript:
 
 generate-golang:
 	cd schema; sed 's|\#/$$defs/modelServerAPI|\#/$$defs/modelServer/$$defs/modelServerAPI|g' model-catalog.schema.json | quicktype -s schema -o types/golang/model-catalog.go --package golang
+
+build-container-location:
+	${CONTAINER_ENGINE} build -t ${LOCATION_SERVICE_IMAGE}:${LOCATION_SERVICE_TAG} -f Dockerfile.location .
+
+build-container-rhoai-normalizer:
+	${CONTAINER_ENGINE} build -t ${RHOAI_NORMALIZER_IMAGE}:${RHOAI_NORMALIZER_TAG} -f Dockerfile.rhoai-normalizer .
+
+build-container-storage-rest:
+	${CONTAINER_ENGINE} build -t ${STORAGE_REST_IMAGE}:${STORAGE_REST_TAG} -f Dockerfile.storage-rest .
+
+build-containers: build-container-location build-container-rhoai-normalizer build-container-storage-rest


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHDHPAI-640

- Makefile targets to build each container image individually, as well as together
- Adds GitHub workflow to build the container images in pull requests
- Adds GitHub workflow to publish the images to quay upon push to main
    - RHOAI Normalizer --> `quay.io/redhat-ai-dev/model-catalog-rhoai-normalizer`
    - Location Service --> `quay.io/redhat-ai-dev/model-catalog-location-service`
    - Storage Rest --> `quay.io/redhat-ai-dev/model-catalog-storage-rest`