### PR TITLE
use json with internal storage format; use 'model-catalog.json' instead of 'catalog-info.yaml' when JsonArrayFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ Either via the command line, or from your favorite Golang editor, set the follow
 3. `BRIDGE_URL` - for now, just use `http://localhost:9090`; this is the REST endpoint of our `location` container
 4. `STORAGE_TYPE` - for now, only the development mode `ConfigMap` is supported; we'll add `GitHub` soon
 5. `K8S_TOKEN`, `KUBECONFIG`, and `NAMESPACE` are the same as above
+6. `NORMALIZER_FORMAT` - can either be `JsonArrayFormat` for our new format from the `schema` folder, or the legacy `CatalogInfoYamlFormat`; if not set defaults to `CatalogInfoYamlFormat` until RHDHPAI-611 and RHDHPAI-612 are completed.
 
 ### location
 
 1. `STORAGE_URL` is the same as above
+2. `NORMALIZER_FORMAT` - can either be `JsonArrayFormat` for our new format from the `schema` folder, or the legacy `CatalogInfoYamlFormat`; if not set defaults to `CatalogInfoYamlFormat` until RHDHPAI-611 and RHDHPAI-612 are completed.
 
 When you are ready to launch the 3 processes, set your current namespace to the `NAMESPACE` value:
 

--- a/cmd/location/main.go
+++ b/cmd/location/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	goflag "flag"
 	gin_gonic_http_srv "github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/server/location/server"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/util"
 	"k8s.io/klog/v2"
 	"os"
@@ -13,7 +14,9 @@ func main() {
 	klog.InitFlags(flagset)
 
 	st := os.Getenv("STORAGE_URL")
-	server := gin_gonic_http_srv.NewImportLocationServer(st)
+	nfstr := os.Getenv(types.FormatEnvVar)
+	nf := types.NormalizerFormat(nfstr)
+	server := gin_gonic_http_srv.NewImportLocationServer(st, nf)
 	stopCh := util.SetupSignalHandler()
 	server.Run(stopCh)
 

--- a/cmd/storage-rest/main.go
+++ b/cmd/storage-rest/main.go
@@ -32,7 +32,10 @@ func main() {
 	bkstgURL := os.Getenv("BKSTG_URL")
 	bkstgToken := os.Getenv("RHDH_TOKEN")
 
-	server := storage.NewStorageRESTServer(bs, bridgeURL, bridgeToken, bkstgURL, bkstgToken)
+	nfstr := os.Getenv(types.FormatEnvVar)
+	nf := types.NormalizerFormat(nfstr)
+
+	server := storage.NewStorageRESTServer(bs, bridgeURL, bridgeToken, bkstgURL, bkstgToken, nf)
 	stopCh := util.SetupSignalHandler()
 	server.Run(stopCh)
 

--- a/pkg/cmd/cli/backstage/interfaces.go
+++ b/pkg/cmd/cli/backstage/interfaces.go
@@ -59,7 +59,7 @@ func PrintModelCatalogPopulator(svrPop ModelCatalogPopulator, writer io.Writer) 
 	if ms.API != nil && len(ms.API.URL) > 0 {
 		modelCatalog.ModelServer = ms
 	}
-	err := util.PrintYaml(modelCatalog, false, writer)
+	err := util.PrintJSON(modelCatalog, writer)
 	if err != nil {
 		klog.Errorf("ERROR: converting ModelCatalog to yaml and printing: %s, %#v", err.Error(), modelCatalog)
 		return err

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
@@ -29,15 +29,15 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 	}{
 		{
 			args:   []string{"Owner", "Lifecycle"},
-			outStr: []string{jsonListOutput},
+			outStr: []string{jsonListOutputJSON},
 		},
 		{
 			args:   []string{"Owner", "Lifecycle", "1"},
-			outStr: []string{jsonListOutput},
+			outStr: []string{jsonListOutputJSON},
 		},
 		{
 			args:   []string{"Owner", "Lifecycle"},
-			outStr: []string{jsonListWithInferenceOutput},
+			outStr: []string{jsonListWithInferenceOutputJSON},
 			is: &serverapiv1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
 					// see test/stub/common/MnistInferenceServices and test/stub/common/MinstServingEnvironment
@@ -122,7 +122,8 @@ func TestLoopOverKFMR_CatalogInfoYaml(t *testing.T) {
 }
 
 const (
-	jsonListWithInferenceOutput = `modelServer:
+	jsonListWithInferenceOutputJSON = `{"models":[{"artifactLocationURL":"https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx","description":"","lifecycle":"Lifecycle","name":"v1","owner":"rhdh-rhoai-bridge","tags":["_lastModified"]}],"modelServer":{"API":{"spec":"","type":"openapi","url":"https://kserve.com"},"authentication":false,"description":"","lifecycle":"development","name":"mnist-v1/8c2c357f-bf82-4d2d-a254-43eca96fd31d","owner":"rhdh-rhoai-bridge","tags":["_lastModified"]}}`
+	jsonListWithInferenceOutputYAML = `modelServer:
   API:
     spec: ""
     type: openapi
@@ -142,7 +143,8 @@ models:
   owner: rhdh-rhoai-bridge
   tags:
   - _lastModified`
-	jsonListOutput = `models:
+	jsonListOutputJSON = `{"models":[{"artifactLocationURL":"https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx","description":"","lifecycle":"Lifecycle","name":"v1","owner":"rhdh-rhoai-bridge","tags":["_lastModified"]}]}`
+	jsonListOutputYAML = `models:
 - artifactLocationURL: https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx
   description: ""
   lifecycle: Lifecycle

--- a/pkg/cmd/server/storage/server.go
+++ b/pkg/cmd/server/storage/server.go
@@ -24,9 +24,10 @@ type StorageRESTServer struct {
 	pushedLocations map[string]*types.StorageBody
 	locations       *bridgeclient.BridgeLocationRESTClient
 	bkstg           rest.BackstageImport
+	format          types.NormalizerFormat
 }
 
-func NewStorageRESTServer(st types.BridgeStorage, bridgeURL, bridgeToken, bkstgURL, bkstgToken string) *StorageRESTServer {
+func NewStorageRESTServer(st types.BridgeStorage, bridgeURL, bridgeToken, bkstgURL, bkstgToken string, nf types.NormalizerFormat) *StorageRESTServer {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 	cfg := &config.Config{
@@ -41,6 +42,7 @@ func NewStorageRESTServer(st types.BridgeStorage, bridgeURL, bridgeToken, bkstgU
 		pushedLocations: map[string]*types.StorageBody{},
 		locations:       bridgeclient.SetupBridgeLocationRESTClient(bridgeURL, bridgeToken),
 		bkstg:           backstage.SetupBackstageRESTClient(cfg),
+		format:          nf,
 	}
 	klog.Infof("NewStorageRESTServer")
 	r.SetTrustedProxies(nil)
@@ -238,7 +240,7 @@ func (s *StorageRESTServer) handleCatalogUpsertPost(c *gin.Context) {
 		return
 	}
 	uri := ""
-	key, uri = util.BuildImportKeyAndURI(segs[0], segs[1])
+	key, uri = util.BuildImportKeyAndURI(segs[0], segs[1], s.format)
 	klog.Infof("Upserting URI %s with key %s with data of len %d", uri, key, len(postBody.Body))
 
 	sb := &types.StorageBody{}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
 	"io"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/klog/v2"
@@ -72,9 +73,13 @@ func ProcessOutput(str string, err error) {
 	}
 }
 
-func BuildImportKeyAndURI(seg1, seg2 string) (string, string) {
+func BuildImportKeyAndURI(seg1, seg2 string, format types.NormalizerFormat) (string, string) {
 	// no spaces in keys
 	seg1 = strings.ReplaceAll(seg1, " ", "")
 	seg2 = strings.ReplaceAll(seg2, " ", "")
-	return fmt.Sprintf("%s_%s", seg1, seg2), fmt.Sprintf("/%s/%s/catalog-info.yaml", seg1, seg2)
+	fn := "catalog-info.yaml"
+	if format == types.JsonArrayForamt {
+		fn = "model-catalog.json"
+	}
+	return fmt.Sprintf("%s_%s", seg1, seg2), fmt.Sprintf("/%s/%s/%s", seg1, seg2, fn)
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -23,6 +24,19 @@ func PrintYaml(obj interface{}, addDivider bool, w io.Writer) error {
 		fmt.Fprintln(w, "---")
 	}
 	return err
+}
+
+func PrintJSON(obj interface{}, w io.Writer) error {
+	writer := printers.GetNewTabWriter(w)
+	output, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(output)
+	if err != nil {
+		return err
+	}
+	return writer.Flush()
 }
 
 var (


### PR DESCRIPTION
format tweak based on @johnmcollier 's plugin testing wrt converting yaml to json

the filename change on the URI is just a way to make the format choice more obvious