### PR TITLE
look for the backstage route in local namespace if not set by env var

### DIFF
--- a/assets/sidecar-after-ai-rhdh-installer/backstage-cr.yaml
+++ b/assets/sidecar-after-ai-rhdh-installer/backstage-cr.yaml
@@ -74,8 +74,6 @@ spec:
                     value: JsonArrayFormat
                   - name: STORAGE_TYPE
                     value: ConfigMap
-                  - name: BKSTG_URL
-                    value: https://backstage-ai-rh-developer-hub-ai-rhdh.apps.gmontero416.devcluster.openshift.com
                   - name: POD_IP
                     valueFrom:
                       fieldRef:
@@ -105,8 +103,6 @@ spec:
                     value: JsonArrayFormat
                   - name: MR_ROUTE
                     value: odh-model-registries-modelregistry-public-rest
-                  - name: BKSTG_URL
-                    value: https://backstage-ai-rh-developer-hub-ai-rhdh.apps.gmontero416.devcluster.openshift.com
                   - name: POD_IP
                     valueFrom:
                       fieldRef:


### PR DESCRIPTION
@johnmcollier @thepetk so with this change we can remove the use of the `BKSTG_URL` env var for the sidecar deployment patch for the bridge 

the env var still takes precedence if it is in fact set

validated with today's test cluster using the methodology 

I'll send you and updated deployment yaml in slack @thepetk 