### PR TITLE
Support key-value pair annotations in the JSON schema

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -10,6 +10,8 @@ The schema can currently be used to map metadata to the Backstage catalog from t
 2) A standalone model, without a server or API exposing it
     - With only `models` specified using the schema
 
+Freeform annotations can be provided on the model and modelServer objects in the form of key-value pairs.
+
 <img width="706" alt="Screenshot 2025-03-17 at 4 10 34 PM" src="https://github.com/user-attachments/assets/6fb4d07c-ffe5-45b0-ae7d-9b8f42eb7e90" />
 
 See below for how the metadata maps into Backstage catalog entities
@@ -28,3 +30,4 @@ In the Backstage Model Catalog:
 ![AI Catalog](https://github.com/redhat-ai-dev/model-catalog-example/blob/main/assets/catalog-graph.png?raw=true "AI Catalog")
 
 A reference model catalog schema can be found [here](https://github.com/redhat-ai-dev/model-catalog-example/blob/main/developer-model-service/catalog-info.yaml)
+

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema can currently be used to map metadata to the Backstage catalog from t
 2) A standalone model, without a server or API exposing it
     - With only `models` specified using the schema
 
-Freeform annotations can be provided on the `models[]`, `modelServer`, and `modelServer.API` objects in the form of key-value pairs (of type string).
+Freeform annotations can be provided on the `models[]`, `modelServer`, and `modelServer.API` objects in the form of key-value pairs (of type string) on the `annotations` proeprty.
 
 <img width="706" alt="Screenshot 2025-03-17 at 4 10 34 PM" src="https://github.com/user-attachments/assets/6fb4d07c-ffe5-45b0-ae7d-9b8f42eb7e90" />
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema can currently be used to map metadata to the Backstage catalog from t
 2) A standalone model, without a server or API exposing it
     - With only `models` specified using the schema
 
-Freeform annotations can be provided on the model and modelServer objects in the form of key-value pairs (of type string).
+Freeform annotations can be provided on the `models[]`, `modelServer`, and `modelServer.API` objects in the form of key-value pairs (of type string).
 
 <img width="706" alt="Screenshot 2025-03-17 at 4 10 34 PM" src="https://github.com/user-attachments/assets/6fb4d07c-ffe5-45b0-ae7d-9b8f42eb7e90" />
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema can currently be used to map metadata to the Backstage catalog from t
 2) A standalone model, without a server or API exposing it
     - With only `models` specified using the schema
 
-Freeform annotations can be provided on the model and modelServer objects in the form of key-value pairs.
+Freeform annotations can be provided on the model and modelServer objects in the form of key-value pairs (of type string).
 
 <img width="706" alt="Screenshot 2025-03-17 at 4 10 34 PM" src="https://github.com/user-attachments/assets/6fb4d07c-ffe5-45b0-ae7d-9b8f42eb7e90" />
 

--- a/schema/model-catalog.schema.json
+++ b/schema/model-catalog.schema.json
@@ -131,6 +131,11 @@
                         "url": {
                             "description": "The URL that the model server's REST API is exposed over, how the model(s) are interacted with",
                             "type": "string"
+                        },
+                        "annotations": {
+                            "description": "Annotations relating to the model, in key-value pair format",
+                            "type": "object",
+                            "additionalProperties": {"type": "string"}
                         }
                     },
                     "additionalProperties": false

--- a/schema/model-catalog.schema.json
+++ b/schema/model-catalog.schema.json
@@ -86,6 +86,11 @@
                 "usage": {
                     "description": "How to use and interact with the model server",
                     "type": "string"
+                },
+                "annotations": {
+                    "description": "Annotations relating to the model server, in key-value pair format",
+                    "type": "object",
+                    "additionalProperties": {"type": "string"}
                 }
             },
             "additionalProperties": false,
@@ -191,6 +196,11 @@
                 "usage": {
                     "description": "How to use and interact with the model",
                     "type": "string"
+                },
+                "annotations": {
+                    "description": "Annotations relating to the model, in key-value pair format",
+                    "type": "object",
+                    "additionalProperties": {"type": "string"}
                 }
             },
             "additionalProperties": false

--- a/schema/tests/005-annotations.json
+++ b/schema/tests/005-annotations.json
@@ -1,0 +1,33 @@
+{
+    "modelServer": {
+      "name": "developer-model-service",
+      "owner": "example-user",
+      "description": "Developer model service running on vLLM",
+      "homepageURL": "https://model-service.apps.example.com",
+      "usage": "Model server usage description",
+      "tags": ["vLLM", "granite", "ibm"],
+      "API": {
+        "url": "https://api.model-service.apps.example.com",
+        "type": "openapi",
+        "spec": "https://raw.githubusercontent.com/redhat-ai-dev/model-catalog-example/refs/heads/main/developer-model-service/openapi.json",
+        "tags": ["openapi", "openai", "3scale"]
+      },
+      "lifecycle": "production",
+      "authentication": true,
+      "annotations": {
+        "some-string": "example",
+        "another-string": "another"
+      }
+    },
+    "models": [
+      {
+        "name": "ibm-granite-20b",
+        "description": "IBM Granite 20b model running on vLLM",
+        "artifactLocationURL": "https://huggingface.co/ibm-granite/granite-20b-code-instruct",
+        "howToUseURL": "https://model-service.apps.example.com/docs",
+        "tags": ["IBM", "granite", "vllm", "20b"],
+        "owner": "example-user",
+        "lifecycle": "production"
+      }
+    ]
+  }

--- a/schema/types/golang/model-catalog.go
+++ b/schema/types/golang/model-catalog.go
@@ -58,15 +58,17 @@ type ModelServer struct {
 // Schema for defining the API exposed by model servers, for conversion to Backstage catalog
 // entities
 type API struct {
-	// A link to the schema used by the model server API                                                 
-	Spec                                                                                        string   `json:"spec"`
-	// Descriptive tags for the model server's API                                                       
-	Tags                                                                                        []string `json:"tags,omitempty"`
-	// The type of API that the model server exposes                                                     
-	Type                                                                                        Type     `json:"type"`
-	// The URL that the model server's REST API is exposed over, how the model(s) are interacted         
-	// with                                                                                              
-	URL                                                                                         string   `json:"url"`
+	// Annotations relating to the model, in key-value pair format                                                
+	Annotations                                                                                 map[string]string `json:"annotations,omitempty"`
+	// A link to the schema used by the model server API                                                          
+	Spec                                                                                        string            `json:"spec"`
+	// Descriptive tags for the model server's API                                                                
+	Tags                                                                                        []string          `json:"tags,omitempty"`
+	// The type of API that the model server exposes                                                              
+	Type                                                                                        Type              `json:"type"`
+	// The URL that the model server's REST API is exposed over, how the model(s) are interacted                  
+	// with                                                                                                       
+	URL                                                                                         string            `json:"url"`
 }
 
 // An AI model to be imported into the Backstage catalog

--- a/schema/types/golang/model-catalog.go
+++ b/schema/types/golang/model-catalog.go
@@ -31,24 +31,26 @@ type ModelCatalog struct {
 //
 // Schema for defining AI model servers, for conversion to Backstage catalog entities
 type ModelServer struct {
-	// The API metadata associated with the model server                         
-	API                                                                 *API     `json:"API,omitempty"`
-	// Whether or not the model server requires authentication to access         
-	Authentication                                                      *bool    `json:"authentication,omitempty"`
-	// A description of the model server and what it's for                       
-	Description                                                         string   `json:"description"`
-	// The URL for the model server's homepage, if present                       
-	HomepageURL                                                         *string  `json:"homepageURL,omitempty"`
-	// The lifecycle state of the model server API                               
-	Lifecycle                                                           string   `json:"lifecycle"`
-	// The name of the model server                                              
-	Name                                                                string   `json:"name"`
-	// The Backstage user that will be responsible for the model server          
-	Owner                                                               string   `json:"owner"`
-	// Descriptive tags for the model server                                     
-	Tags                                                                []string `json:"tags,omitempty"`
-	// How to use and interact with the model server                             
-	Usage                                                               *string  `json:"usage,omitempty"`
+	// Annotations relating to the model server, in key-value pair format                  
+	Annotations                                                          map[string]string `json:"annotations,omitempty"`
+	// The API metadata associated with the model server                                   
+	API                                                                  *API              `json:"API,omitempty"`
+	// Whether or not the model server requires authentication to access                   
+	Authentication                                                       *bool             `json:"authentication,omitempty"`
+	// A description of the model server and what it's for                                 
+	Description                                                          string            `json:"description"`
+	// The URL for the model server's homepage, if present                                 
+	HomepageURL                                                          *string           `json:"homepageURL,omitempty"`
+	// The lifecycle state of the model server API                                         
+	Lifecycle                                                            string            `json:"lifecycle"`
+	// The name of the model server                                                        
+	Name                                                                 string            `json:"name"`
+	// The Backstage user that will be responsible for the model server                    
+	Owner                                                                string            `json:"owner"`
+	// Descriptive tags for the model server                                               
+	Tags                                                                 []string          `json:"tags,omitempty"`
+	// How to use and interact with the model server                                       
+	Usage                                                                *string           `json:"usage,omitempty"`
 }
 
 // The API metadata associated with the model server
@@ -71,28 +73,30 @@ type API struct {
 //
 // Schema for defining AI models conversion to Backstage catalog entities
 type Model struct {
-	// A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc                     
-	ArtifactLocationURL                                                                          *string  `json:"artifactLocationURL,omitempty"`
-	// A description of the model and what it's for                                                       
-	Description                                                                                  string   `json:"description"`
-	// Any ethical considerations for the model                                                           
-	Ethics                                                                                       *string  `json:"ethics,omitempty"`
-	// The URL pointing to any specific documentation on how to use the model on the model server         
-	HowToUseURL                                                                                  *string  `json:"howToUseURL,omitempty"`
-	// The lifecycle state of the model server API                                                        
-	Lifecycle                                                                                    string   `json:"lifecycle"`
-	// The name of the model                                                                              
-	Name                                                                                         string   `json:"name"`
-	// The Backstage user that will be responsible for the model                                          
-	Owner                                                                                        string   `json:"owner"`
-	// Support information for the model / where to open issues                                           
-	Support                                                                                      *string  `json:"support,omitempty"`
-	// Descriptive tags for the model                                                                     
-	Tags                                                                                         []string `json:"tags,omitempty"`
-	// Information on how the model was trained                                                           
-	Training                                                                                     *string  `json:"training,omitempty"`
-	// How to use and interact with the model                                                             
-	Usage                                                                                        *string  `json:"usage,omitempty"`
+	// Annotations relating to the model, in key-value pair format                                                 
+	Annotations                                                                                  map[string]string `json:"annotations,omitempty"`
+	// A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc                              
+	ArtifactLocationURL                                                                          *string           `json:"artifactLocationURL,omitempty"`
+	// A description of the model and what it's for                                                                
+	Description                                                                                  string            `json:"description"`
+	// Any ethical considerations for the model                                                                    
+	Ethics                                                                                       *string           `json:"ethics,omitempty"`
+	// The URL pointing to any specific documentation on how to use the model on the model server                  
+	HowToUseURL                                                                                  *string           `json:"howToUseURL,omitempty"`
+	// The lifecycle state of the model server API                                                                 
+	Lifecycle                                                                                    string            `json:"lifecycle"`
+	// The name of the model                                                                                       
+	Name                                                                                         string            `json:"name"`
+	// The Backstage user that will be responsible for the model                                                   
+	Owner                                                                                        string            `json:"owner"`
+	// Support information for the model / where to open issues                                                    
+	Support                                                                                      *string           `json:"support,omitempty"`
+	// Descriptive tags for the model                                                                              
+	Tags                                                                                         []string          `json:"tags,omitempty"`
+	// Information on how the model was trained                                                                    
+	Training                                                                                     *string           `json:"training,omitempty"`
+	// How to use and interact with the model                                                                      
+	Usage                                                                                        *string           `json:"usage,omitempty"`
 }
 
 // The type of API that the model server exposes

--- a/schema/types/typescript/index.d.ts
+++ b/schema/types/typescript/index.d.ts
@@ -69,6 +69,10 @@ export interface ModelServer {
  */
 export interface API {
     /**
+     * Annotations relating to the model, in key-value pair format
+     */
+    annotations?: { [key: string]: string };
+    /**
      * A link to the schema used by the model server API
      */
     spec: string;

--- a/schema/types/typescript/index.d.ts
+++ b/schema/types/typescript/index.d.ts
@@ -20,6 +20,10 @@ export interface ModelCatalog {
  */
 export interface ModelServer {
     /**
+     * Annotations relating to the model server, in key-value pair format
+     */
+    annotations?: { [key: string]: string };
+    /**
      * The API metadata associated with the model server
      */
     API?: API;
@@ -99,6 +103,10 @@ export enum Type {
  * Schema for defining AI models conversion to Backstage catalog entities
  */
 export interface Model {
+    /**
+     * Annotations relating to the model, in key-value pair format
+     */
+    annotations?: { [key: string]: string };
     /**
      * A URL to access the model's artifacts, e.g. on HuggingFace, Minio, Github, etc
      */


### PR DESCRIPTION
I was looking into how we could handle key-value pairs in the JSON schema and this looked easy enough to implement. 

By default, setting `type: object` on a given field in a JSON schema will allow for any kind of key value pairs to be entered. We can further restrict this to just strings (e.g. as is typical with annotations in Kubernetes) by setting `"additionalProperties": {"type": "string"}`