### PR TITLE
RHDHPAI-611: Include dynamic-plugins.yaml patch for configuring model-catalog plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,19 @@ The steps involved **AFTER** running the 'ai-rhdh-installer' are as follows:
 - with the entire `deployment` section from [./assets/sidecar-after-ai-rhdh-installer/backstage-cr.yaml](assets/sidecar-after-ai-rhdh-installer/backstage-cr.yaml)
 - watch the `backstage-ai-rh-developer-hub...` Pod recycle (the new Pod will now have 4 containers, including the bridge's `location`, `storage-rest`, and `rhoai-normalizer` containers)
 - after RHDH Pod restart has completed successfully, once models are defined in the ODH/RHOAI model registry, you'll see the `bac-import-model` ConfigMap populated with entries for those models 
+
+### Deploying the Model Catalog RHDH Plugin
+
+If you wish to run the Model Catalog plugin in a remote instance of RHDH, the steps are as follows:
+
+- If your Backstage custom resource already has a dynamic plugins configmap listed under `spec.application.dynamicPluginsConfigMapName`, modify the ConfigMap to add the following entry under `dynamic-plugins.yaml`:
+
+```
+    plugins:
+      - package: oci://quay.io/redhat-ai-dev/ai-integrations-rhdh:latest!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog
+        disabled: false
+```
+
+- If you do not have a ConfigMap listed under `spec.application.dynamicPluginsConfigMapName`, then you may use [./assets/sidecar-after-ai-rhdh-installer/dynamic-plugin-patches.yaml](./assets/sidecar-after-ai-rhdh-installer/dynamic-plugin-patches.yaml) as a reference point. 
+
+    - After the ConfigMap has been created, modify the Backstage CR to specify the ConfigMap name under `spec.application.dynamicPluginsConfigMapName`

--- a/assets/sidecar-after-ai-rhdh-installer/dynamic-plugin-patches.yaml
+++ b/assets/sidecar-after-ai-rhdh-installer/dynamic-plugin-patches.yaml
@@ -1,0 +1,19 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  # There will be a pre-existing dynamic plugins already present if you followed the installer
+  # in which case, modify the existing configmap to add the plugin entry in
+  name: backstage-ai-rh-developer-hub-dynamic-plugins-3c140ae5afb4
+  labels:
+    rhdh.redhat.com/ext-config-sync: 'true'
+  annotations:
+    rhdh.redhat.com/backstage-name: developer-hub
+data:
+  dynamic-plugins.yaml: |
+    includes:
+      - dynamic-plugins.default.yaml
+    # The following specifies that the model catalog plugin (red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog)
+    # contained within the OCI archive (quay.io/redhat-ai-dev/ai-integrations-rhdh:latest) should be installed into RHDH
+    plugins:
+      - package: oci://quay.io/redhat-ai-dev/ai-integrations-rhdh:latest!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog
+        disabled: false


### PR DESCRIPTION
Adds a simple dynamic-plugins.yaml to the sidecar assets to show how to patch the dynamic plugins configmap in an RHDH install to enable the model catalog plugin for the Bridge sidecar