### PR TITLE
Sanitize inference server names

### DIFF
--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -351,7 +351,7 @@ func (m *ModelServerPopulator) GetName() string {
 func sanitizeName(name string) string {
 	sanitizedName := name
 
-	// Replace any invalid characters with an empty space
+	// Replace any invalid characters with an empty character
 	validChars := regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
 	sanitizedName = validChars.ReplaceAllString(sanitizedName, "")
 

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -340,22 +340,28 @@ func (m *ModelServerPopulator) GetAuthentication() *bool {
 
 func (m *ModelServerPopulator) GetName() string {
 	if len(m.InferenceServices) > m.InfSvcIndex {
-		msName := m.InferenceServices[m.InfSvcIndex].GetName()
-
-		// Strip out any invalid characters
-		validChars := regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
-		msName = validChars.ReplaceAllString(msName, "")
-
-		// Trim to 63 characters if it's over the maximum length
-		if len(msName) > 63 {
-			msName = msName[:63]
-		}
-
-		// Ensure only alphanumeric characters at beginning and end of the name
-		msName = strings.TrimRight(msName, "-_.")
-		return msName
+		sanitizedName := sanitizeName(m.InferenceServices[m.InfSvcIndex].GetName())
+		return sanitizedName
 	}
 	return ""
+}
+
+func sanitizeName(name string) string {
+	sanitizedName := name
+	validChars := regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
+	sanitizedName = validChars.ReplaceAllString(sanitizedName, "")
+
+	// Remove duplicated special characters
+	noDupeChars := regexp.MustCompile(`[-_.]{2,}`)
+	sanitizedName = noDupeChars.ReplaceAllString(sanitizedName, "")
+	if len(sanitizedName) > 63 {
+		sanitizedName = sanitizedName[:63]
+	}
+
+	// Ensure only alphanumeric characters at beginning and end of the name
+	sanitizedName = strings.Trim(sanitizedName, "-_.")
+	return sanitizedName
+
 }
 
 func (m *ModelServerPopulator) GetTags() []string {

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -338,6 +338,8 @@ func (m *ModelServerPopulator) GetAuthentication() *bool {
 	return &auth
 }
 
+// GetName returns the inference server name, sanitized to meet the following criteria
+// "a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total"
 func (m *ModelServerPopulator) GetName() string {
 	if len(m.InferenceServices) > m.InfSvcIndex {
 		sanitizedName := sanitizeName(m.InferenceServices[m.InfSvcIndex].GetName())
@@ -348,17 +350,21 @@ func (m *ModelServerPopulator) GetName() string {
 
 func sanitizeName(name string) string {
 	sanitizedName := name
+
+	// Replace any invalid characters with an empty space
 	validChars := regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
 	sanitizedName = validChars.ReplaceAllString(sanitizedName, "")
 
 	// Remove duplicated special characters
 	noDupeChars := regexp.MustCompile(`[-_.]{2,}`)
 	sanitizedName = noDupeChars.ReplaceAllString(sanitizedName, "")
+
+	// Trim to no more than 63 characters
 	if len(sanitizedName) > 63 {
 		sanitizedName = sanitizedName[:63]
 	}
 
-	// Ensure only alphanumeric characters at beginning and end of the name
+	// Finally, ensure only alphanumeric characters at beginning and end of the name
 	sanitizedName = strings.Trim(sanitizedName, "-_.")
 	return sanitizedName
 

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 
 	serverv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kubeflow/model-registry/pkg/openapi"
@@ -339,7 +340,20 @@ func (m *ModelServerPopulator) GetAuthentication() *bool {
 
 func (m *ModelServerPopulator) GetName() string {
 	if len(m.InferenceServices) > m.InfSvcIndex {
-		return m.InferenceServices[m.InfSvcIndex].GetName()
+		msName := m.InferenceServices[m.InfSvcIndex].GetName()
+
+		// Strip out any invalid characters
+		validChars := regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
+		msName = validChars.ReplaceAllString(msName, "")
+
+		// Trim to 63 characters if it's over the maximum length
+		if len(msName) > 63 {
+			msName = msName[:63]
+		}
+
+		// Ensure only alphanumeric characters at beginning and end of the name
+		msName = strings.TrimRight(msName, "-_.")
+		return msName
 	}
 	return ""
 }

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
@@ -123,7 +123,7 @@ func TestLoopOverKFMR_CatalogInfoYaml(t *testing.T) {
 }
 
 const (
-	jsonListWithInferenceOutputJSON = `{"models":[{"artifactLocationURL":"https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx","description":"","lifecycle":"Lifecycle","name":"mnist-v1","owner":"rhdh-rhoai-bridge","tags":["_lastModified"]}],"modelServer":{"API":{"spec":"","type":"openapi","url":"https://kserve.com"},"authentication":false,"description":"","lifecycle":"development","name":"mnist-v1/8c2c357f-bf82-4d2d-a254-43eca96fd31d","owner":"rhdh-rhoai-bridge","tags":["_lastModified"]}}`
+	jsonListWithInferenceOutputJSON = `{"models":[{"artifactLocationURL":"https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx","description":"","lifecycle":"Lifecycle","name":"mnist-v1","owner":"rhdh-rhoai-bridge","tags":["_lastModified"]}],"modelServer":{"API":{"spec":"","type":"openapi","url":"https://kserve.com"},"authentication":false,"description":"","lifecycle":"development","name":"mnist-v18c2c357f-bf82-4d2d-a254-43eca96fd31d","owner":"rhdh-rhoai-bridge","tags":["_lastModified"]}}`
 	jsonListWithInferenceOutputYAML = `modelServer:
   API:
     spec: ""


### PR DESCRIPTION
Sanitize the inference server name before storing it as part of the ModelCatalog JSON obejct, to meet the criteria imposed by the Backstage catalog:
   - _a string that is a sequence of [a-zA-Z0-9] separated by any of [-\_.], at most 63 characters in total_

Specifically, adds a function, `sanitizeName` that is called when we retrieve the inference server name, which does the following

  - Remove any invalid characters, and replace with an empty space
  - Remove any allowed special characters that occur twice or more (alphanumerical characters can only be separated by one special character)
  - Trims the string a max of 63 characters
  - Removes any leading or trailing special characters
  
Previously, we had some discussions (see https://github.com/redhat-developer/rhdh-plugins/pull/605#discussion_r2033793608) over how much sanitization we wanted to do with tags, but since a `metadata.name` is a required field for catalog entities, some sanitization is needed here (whereas we can skip over invalid tags).

If this sanitization should be moved to the plugin, I'm open to doing that as well. Or if we want to minimize the sanitization done, I'm also open to that