### PR TITLE
fix timing issues between location start load and storage upsert

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,14 +1,13 @@
 package util
 
 const (
-	DefaultOwner          = "rhdh-rhoai-bridge"
-	DefaultLifecycle      = "development"
-	StorageConfigMapName  = "bac-import-model"
-	KeyQueryParam         = "key"
-	UpsertURI             = "/upsert"
-	CurrentKeySetURI      = "/currentkeyset"
-	RemoveURI             = "/remove"
-	ListURI               = "/list"
-	FetchURI              = "/fetch"
-	BackgroundStoragePoll = "/backgroundstoragepoll"
+	DefaultOwner         = "rhdh-rhoai-bridge"
+	DefaultLifecycle     = "development"
+	StorageConfigMapName = "bac-import-model"
+	KeyQueryParam        = "key"
+	UpsertURI            = "/upsert"
+	CurrentKeySetURI     = "/currentkeyset"
+	RemoveURI            = "/remove"
+	ListURI              = "/list"
+	FetchURI             = "/fetch"
 )


### PR DESCRIPTION
turns our if the location background's load from storage and the storage service's upsert happened at the same time, we could get panic's in go-gonic registering the REST endpoing

rather than complicate the path with synchronization logic, just doing a one time attempt to load from storage before the location service registeres the upsert REST endpoint; if it works great, if it does not, we'll just wait for the up to 2 minutes for the reconciler poll to grigger the upsert flow