### PR TITLE
re-enable bridge push to rhdh catalog

### DIFF
--- a/pkg/cmd/server/storage/server.go
+++ b/pkg/cmd/server/storage/server.go
@@ -294,33 +294,32 @@ func (s *StorageRESTServer) handleCatalogUpsertPost(c *gin.Context) {
 		return
 	}
 
-	//impResp := map[string]any{}
+	impResp := map[string]any{}
 	bkstAvailable := s.setupBkstg()
 	if !bkstAvailable {
 		klog.Warningf("Access to Backstage is not available so will not import location %s", sb.LocationId)
 	} else {
-		//TODO temp disable while we sort out adding the rhdh-rhoai-bridge type to backstage when running in RHDH
 
-		//impResp, err = s.bkstg.ImportLocation(s.locations.HostURL + uri)
-		//if err != nil {
-		//	c.Status(http.StatusInternalServerError)
-		//	msg = fmt.Sprintf("error importing location %s to backstage: %s", s.locations.HostURL+uri, err.Error())
-		//	klog.Errorf(msg)
-		//	c.Error(fmt.Errorf(msg))
-		//	return
-		//}
-		//retID, retTarget, rok := rest.ParseImportLocationMap(impResp)
-		//if !rok {
-		//	//TODO perhaps delete location on the backstage side as well as our cache
-		//	c.Status(http.StatusBadRequest)
-		//	msg = fmt.Sprintf("parsing of import location return had an issue: %#v", impResp)
-		//	klog.Errorf(msg)
-		//	c.Error(fmt.Errorf(msg))
-		//	return
-		//}
-		//
-		//sb.LocationId = retID
-		//sb.LocationTarget = retTarget
+		impResp, err = s.bkstg.ImportLocation(s.locations.HostURL + uri)
+		if err != nil {
+			c.Status(http.StatusInternalServerError)
+			msg = fmt.Sprintf("error importing location %s to backstage: %s", s.locations.HostURL+uri, err.Error())
+			klog.Errorf(msg)
+			c.Error(fmt.Errorf(msg))
+			return
+		}
+		retID, retTarget, rok := rest.ParseImportLocationMap(impResp)
+		if !rok {
+			//TODO perhaps delete location on the backstage side as well as our cache
+			c.Status(http.StatusBadRequest)
+			msg = fmt.Sprintf("parsing of import location return had an issue: %#v", impResp)
+			klog.Errorf(msg)
+			c.Error(fmt.Errorf(msg))
+			return
+		}
+
+		sb.LocationId = retID
+		sb.LocationTarget = retTarget
 
 	}
 	// finally store in our storage layer with the id and cross reference location URL from backstage

--- a/pkg/cmd/server/storage/server_test.go
+++ b/pkg/cmd/server/storage/server_test.go
@@ -160,12 +160,10 @@ func Test_handleCatalogUpsertPost_handleCatalogCurrentKeySetPost_ConfigMap(t *te
 			expectedSC: http.StatusCreated,
 		},
 		{
-			name:   "updated entry",
-			reqURL: url.URL{RawQuery: "key=mnist_v1"},
-			body:   rest.PostBody{Body: []byte("update")},
-			//TODO temporarily changed until we sort out registering the rhdh-rhoai-bridge import type in RHDH
-			//expectedSC: http.StatusOK,
-			expectedSC: http.StatusCreated,
+			name:       "updated entry",
+			reqURL:     url.URL{RawQuery: "key=mnist_v1"},
+			body:       rest.PostBody{Body: []byte("update")},
+			expectedSC: http.StatusOK,
 		},
 	} {
 		testWriter := testgin.NewTestResponseWriter()
@@ -228,8 +226,7 @@ func Test_handleCatalogUpsertPost_handleCatalogCurrentKeySetPost_ConfigMap(t *te
 				return true
 			})
 			// backstage called
-			//TODO temporarily disabled until we sort out registering the rhdh-rhoai-bridge import type in RHDH
-			//common.AssertEqual(t, true, found)
+			common.AssertEqual(t, true, found)
 
 			// clear out call cache for next check
 			for _, k := range keyList {
@@ -293,8 +290,7 @@ func Test_handleCatalogUpsertPost_handleCatalogCurrentKeySetPost_ConfigMap(t *te
 	_, ok := locationCallback.Load("delete")
 	common.AssertEqual(t, true, ok)
 
-	//TODO temp disable until we sort out how to register rhdh-rhoai-bridge import type into RHDH
-	//_, ok = backstageCallback.Load("delete")
-	//common.AssertEqual(t, true, ok)
+	_, ok = backstageCallback.Load("delete")
+	common.AssertEqual(t, true, ok)
 
 }


### PR DESCRIPTION
in anticipation of my discovery that we need separate dynamic plugins whose names match the moduleID passed into the `createBackendModule` calls when the catalog plugin registers entity provider, catalog processor, or location extension.

the model catalog entity provider was the only one whose name matched the  catalog plugin `catalog-backend-module-model-catalog` over at https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/ai-integrations/plugins/catalog-backend-module-model-catalog

also with this PR we'll more easily be able to toggle back and forth short term (i.e. revert if need be) as well as better scope how we might want to make push configurable 

@johnmcollier @thepetk 