### PR TITLE
allow for bypass of podIP for sidecar with 'BRIDGE_URL' env var

### DIFF
--- a/assets/sidecar-after-ai-rhdh-installer/backstage-cr.yaml
+++ b/assets/sidecar-after-ai-rhdh-installer/backstage-cr.yaml
@@ -74,6 +74,10 @@ spec:
                     value: JsonArrayFormat
                   - name: STORAGE_TYPE
                     value: ConfigMap
+                  - name: PUSH_TO_RHDH
+                    value: true
+                  - name: BRIDGE_URL
+                    value: http://localhost:9090
                   - name: POD_IP
                     valueFrom:
                       fieldRef:

--- a/assets/sidecar-after-ai-rhdh-installer/dynamic-plugin-patches.yaml
+++ b/assets/sidecar-after-ai-rhdh-installer/dynamic-plugin-patches.yaml
@@ -14,6 +14,13 @@ data:
       - dynamic-plugins.default.yaml
     # The following specifies that the model catalog plugin (red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog)
     # contained within the OCI archive (quay.io/redhat-ai-dev/ai-integrations-rhdh:latest) should be installed into RHDH
+    # officially built images are at oci://quay.io/redhat-ai-dev/ai-integrations-rhdh:latest but 
+    # the 'consolidate-ai-catalog-extensions' branch from the gabemontero fork of the plugins produced these plugin images 
+    # allow for push import with sidecars
     plugins:
-      - package: oci://quay.io/redhat-ai-dev/ai-integrations-rhdh:latest!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog
+      - package: oci://quay.io/gabemontero/ai-experience:v5!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog
+        disabled: false
+      - package: oci://quay.io/gabemontero/ai-experience:v5!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog-location-extension
+        disabled: false
+      - package: oci://quay.io/gabemontero/ai-experience:v5!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog-reader
         disabled: false

--- a/cmd/storage-rest/main.go
+++ b/cmd/storage-rest/main.go
@@ -32,6 +32,7 @@ func main() {
 
 	bridgeURL := os.Getenv(types.LocationUrlEnvVar)
 	bridgeURL = r.Replace(bridgeURL)
+	klog.Infof("%s set to %s", types.LocationUrlEnvVar, bridgeURL)
 	bridgeToken := util.GetCurrentToken(restConfig)
 
 	bkstgToken := os.Getenv(types.RHDHTokenEnvVar)
@@ -40,9 +41,10 @@ func main() {
 	podIP := os.Getenv(util.PodIPEnvVar)
 	podIP = r.Replace(podIP)
 	klog.Infof("pod IP from env var is %s", podIP)
-	if len(podIP) > 0 {
+	if len(podIP) > 0 && len(bridgeURL) == 0 {
 		// neither inter-Pod nor service IPs worked for backstage access in testing; have to use the route
 		bridgeURL = fmt.Sprintf("http://%s:9090", podIP)
+		klog.Infof("using %s env var vs. %s for location service access", util.PodIPEnvVar, types.LocationUrlEnvVar)
 	}
 
 	nfstr := os.Getenv(types.FormatEnvVar)


### PR DESCRIPTION
and associated sidecar related config changes

with this change, I was able to configure RHDH plus sidecars and validate push of catalog changes to the catalog processor:

![push-location-working-sidecar](https://github.com/user-attachments/assets/021ad9cf-9761-4567-af53-932729aed7e7)
