### PR TITLE
fixes to the catalog-info yaml path

### DIFF
--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -769,6 +769,7 @@ func CallBackstagePrinters(ctx context.Context, owner, lifecycle string, rm *ope
 		resPop.ModelVersions = mvs
 		resPop.Kis = is
 		resPop.CtrlClient = client
+		resPop.Ctx = ctx
 		for _, mv := range mvs {
 			resPop.ModelVersion = &mv
 			m, _ := mas[*mv.Id]
@@ -788,6 +789,7 @@ func CallBackstagePrinters(ctx context.Context, owner, lifecycle string, rm *ope
 		apiPop.InferenceServices = isl
 		apiPop.Kis = is
 		apiPop.CtrlClient = client
+		apiPop.Ctx = ctx
 		return backstage.PrintAPI(&apiPop, writer)
 	}
 

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -810,6 +810,9 @@ type CommonPopulator struct {
 }
 
 func (pop *CommonPopulator) GetOwner() string {
+	if len(pop.Owner) != 0 {
+		return pop.Owner
+	}
 	if pop.RegisteredModel.Owner != nil {
 		return util.SanitizeName(*pop.RegisteredModel.Owner)
 	}

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
@@ -516,7 +516,7 @@ spec:
   - resource:v1
   - api:model-1-v1-artifact
   lifecycle: Lifecycle
-  owner: user:kubeadmin
+  owner: user:Owner
   profile:
     displayName: model-1
   type: model-server
@@ -537,7 +537,7 @@ spec:
   dependencyOf:
   - component:model-1
   lifecycle: Lifecycle
-  owner: user:kubeadmin
+  owner: user:Owner
   profile:
     displayName: v1
   type: ai-model
@@ -554,7 +554,7 @@ spec:
   dependencyOf:
   - component:model-1
   lifecycle: Lifecycle
-  owner: user:kubeadmin
+  owner: user:Owner
   profile:
     displayName: model-1
   type: unknown


### PR DESCRIPTION
does not affect json array path used by the bridge sidecars communicating with the backstage model catalog plugin

uncovered while rebasing the cli over at https://github.com/redhat-ai-dev/rhdh-ai-catalog-cli to the version of this repo used for the summit demo