### PR TITLE
re-enable kserve only normalization

### DIFF
--- a/assets/kserve-only-model-test-deploy/mnist/auth-sa.yaml
+++ b/assets/kserve-only-model-test-deploy/mnist/auth-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mnist-v1-sa

--- a/assets/kserve-only-model-test-deploy/mnist/connection-secret.yaml
+++ b/assets/kserve-only-model-test-deploy/mnist/connection-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  URI: aHR0cHM6Ly9odWdnaW5nZmFjZS5jby90YXJpbGFicy9tbmlzdC9yZXNvbHZlL3YyMDIzMTIwNjE2MzAyOC9tbmlzdC5vbm54
+kind: Secret
+metadata:
+  annotations:
+    opendatahub.io/connection-type-ref: uri-v1
+    openshift.io/description: ""
+    openshift.io/display-name: mnist
+  name: mnist
+type: Opaque

--- a/assets/kserve-only-model-test-deploy/mnist/infererenceservice.yaml
+++ b/assets/kserve-only-model-test-deploy/mnist/infererenceservice.yaml
@@ -1,0 +1,28 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    openshift.io/display-name: mnist - v1
+    security.opendatahub.io/enable-auth: "true"
+    serving.kserve.io/deploymentMode: RawDeployment
+  labels:
+    networking.kserve.io/visibility: exposed
+  name: mnist-v1
+spec:
+  predictor:
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      modelFormat:
+        name: onnx
+        version: "1"
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 8Gi
+        requests:
+          cpu: "1"
+          memory: 4Gi
+      runtime: mnist-v1
+      storageUri: https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx

--- a/assets/kserve-only-model-test-deploy/mnist/servingruntimes.yaml
+++ b/assets/kserve-only-model-test-deploy/mnist/servingruntimes.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: mnist-v1
+spec:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8888"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --port=8001
+    - --rest_port=8888
+    - --model_path=/mnt/models
+    - --file_system_poll_wait_seconds=0
+    - --grpc_bind_address=0.0.0.0
+    - --rest_bind_address=0.0.0.0
+    - --target_device=AUTO
+    - --metrics_enable
+    image: quay.io/modh/openvino_model_server@sha256:53b7fcf95de9b81e4c8652d0bf4e84e22d5b696827a5d951d863420c68b9cfe8
+    name: kserve-container
+    ports:
+    - containerPort: 8888
+      protocol: TCP
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: shm
+  multiModel: false
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: openvino_ir
+    version: opset13
+  - name: onnx
+    version: "1"
+  - autoSelect: true
+    name: tensorflow
+    version: "1"
+  - autoSelect: true
+    name: tensorflow
+    version: "2"
+  - autoSelect: true
+    name: paddle
+    version: "2"
+  - autoSelect: true
+    name: pytorch
+    version: "2"
+  volumes:
+  - emptyDir:
+      medium: Memory
+      sizeLimit: 2Gi
+    name: shm

--- a/pkg/cmd/cli/kserve/kserve.go
+++ b/pkg/cmd/cli/kserve/kserve.go
@@ -2,17 +2,23 @@ package kserve
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
-	"strings"
-
 	serverapiv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/backstage"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
+	brdgtypes "github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/util"
+	"github.com/redhat-ai-dev/model-catalog-bridge/schema/types/golang"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
+	"net/url"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 const (
@@ -29,9 +35,11 @@ const (
 )
 
 type CommonPopulator struct {
-	Owner     string
-	Lifecycle string
-	InferSvc  *serverapiv1beta1.InferenceService
+	Owner      string
+	Lifecycle  string
+	InferSvc   *serverapiv1beta1.InferenceService
+	CtrlClient client.Client
+	Ctx        context.Context
 }
 
 func (pop *CommonPopulator) GetOwner() string {
@@ -248,29 +256,428 @@ func SetupKServeClient(cfg *config.Config) {
 
 }
 
-func CallBackstagePrinters(owner, lifecycle string, is *serverapiv1beta1.InferenceService, writer io.Writer) error {
+func CallBackstagePrinters(ctx context.Context, owner, lifecycle string, is *serverapiv1beta1.InferenceService, client client.Client, writer io.Writer, format brdgtypes.NormalizerFormat) error {
 	compPop := ComponentPopulator{}
 	compPop.Owner = owner
 	compPop.Lifecycle = lifecycle
 	compPop.InferSvc = is
-	err := backstage.PrintComponent(&compPop, writer)
-	if err != nil {
+	compPop.CtrlClient = client
+	compPop.Ctx = ctx
+
+	switch format {
+	case brdgtypes.JsonArrayForamt:
+		mcPop := ModelCatalogPopulator{CommonSchemaPopulator: CommonSchemaPopulator{compPop}}
+		msPop := ModelServerPopulator{
+			CommonSchemaPopulator: CommonSchemaPopulator{compPop},
+			ApiPop:                ModelServerAPIPopulator{CommonSchemaPopulator: CommonSchemaPopulator{compPop}},
+		}
+		mcPop.MSPop = &msPop
+		return backstage.PrintModelCatalogPopulator(&mcPop, writer)
+
+	case brdgtypes.CatalogInfoYamlFormat:
+	default:
+		err := backstage.PrintComponent(&compPop, writer)
+		if err != nil {
+			return err
+		}
+
+		resPop := ResourcePopulator{}
+		resPop.Owner = owner
+		resPop.Lifecycle = lifecycle
+		resPop.InferSvc = is
+		resPop.CtrlClient = client
+		resPop.Ctx = ctx
+		err = backstage.PrintResource(&resPop, writer)
+		if err != nil {
+			return err
+		}
+
+		apiPop := ApiPopulator{}
+		apiPop.Owner = owner
+		apiPop.Lifecycle = lifecycle
+		apiPop.InferSvc = is
+		apiPop.CtrlClient = client
+		apiPop.Ctx = ctx
+		err = backstage.PrintAPI(&apiPop, writer)
 		return err
 	}
+	return nil
+}
 
-	resPop := ResourcePopulator{}
-	resPop.Owner = owner
-	resPop.Lifecycle = lifecycle
-	resPop.InferSvc = is
-	err = backstage.PrintResource(&resPop, writer)
-	if err != nil {
-		return err
+// json array schema populator
+
+type CommonSchemaPopulator struct {
+	// reuse the component populator as it houses all the KFMR artifacts of noew
+	ComponentPopulator
+}
+
+func fixKeyForAnnotation(key string) string {
+	key = strings.ToLower(key)
+	replacer := strings.NewReplacer(" ", "")
+	key = replacer.Replace(key)
+	return key
+}
+
+func commonGetStringPropVal(key string, is *serverapiv1beta1.InferenceService) *string {
+	if is == nil {
+		return nil
+	}
+	retString := ""
+
+	if is.Annotations == nil {
+		return nil
 	}
 
-	apiPop := ApiPopulator{}
-	apiPop.Owner = owner
-	apiPop.Lifecycle = lifecycle
-	apiPop.InferSvc = is
-	err = backstage.PrintAPI(&apiPop, writer)
-	return err
+	val, ok := is.Annotations[fmt.Sprintf("%s%s", brdgtypes.AnnotationPrefix, fixKeyForAnnotation(key))]
+	if !ok {
+		return nil
+	}
+	retString = val
+
+	return &retString
+}
+
+type ModelServerPopulator struct {
+	CommonSchemaPopulator
+	ApiPop ModelServerAPIPopulator
+}
+
+func (m *ModelServerPopulator) getStringPropVal(key string) *string {
+	return commonGetStringPropVal(key, m.InferSvc)
+}
+
+func (m *ModelServerPopulator) GetUsage() *string {
+	return m.getStringPropVal(brdgtypes.UsageKey)
+}
+
+func (m *ModelServerPopulator) GetHomepageURL() *string {
+	return m.getStringPropVal(brdgtypes.HomepageURLKey)
+}
+
+func (m *ModelServerPopulator) GetAuthentication() *bool {
+	auth := false
+	// when auth is configured, a service account is created whose name is prefixed with the inference service's name, and with the
+	// inference service set as an owner reference
+
+	listOptions := &client.ListOptions{Namespace: m.InferSvc.Namespace}
+	saList := &corev1.ServiceAccountList{}
+	err := m.CtrlClient.List(m.Ctx, saList, listOptions)
+	if err != nil {
+		return &auth
+	}
+	for _, sa := range saList.Items {
+		if sa.OwnerReferences == nil {
+			continue
+		}
+		for _, o := range sa.OwnerReferences {
+			if o.Kind == "InferenceService" &&
+				o.Name == m.InferSvc.Name {
+				auth = true
+				break
+			}
+		}
+	}
+	return &auth
+}
+
+// GetName returns the inference server name, sanitized to meet the following criteria
+// "a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total"
+func (m *ModelServerPopulator) GetName() string {
+	name := fmt.Sprintf("%s-%s", util.SanitizeName(m.InferSvc.Namespace), util.SanitizeName(m.InferSvc.Name))
+	return util.SanitizeName(name)
+}
+
+func (m *ModelServerPopulator) GetTags() []string {
+	tags := []string{}
+	for k, v := range m.InferSvc.Labels {
+		tag := fmt.Sprintf("%s-%s", util.SanitizeName(k), util.SanitizeName(v))
+		tags = append(tags, util.SanitizeName(tag))
+	}
+	return tags
+}
+
+func (m *ModelServerPopulator) GetAPI() *golang.API {
+	m.ApiPop.Ctx = m.Ctx
+	api := &golang.API{
+		Spec: m.ApiPop.GetSpec(),
+		Tags: m.ApiPop.GetTags(),
+		Type: m.ApiPop.GetType(),
+		URL:  m.ApiPop.GetURL(),
+	}
+	return api
+}
+
+func (m *ModelServerPopulator) GetOwner() string {
+	owner := m.getStringPropVal(brdgtypes.Owner)
+	if owner != nil {
+		return util.SanitizeName(*owner)
+	}
+	return m.Owner
+}
+
+func (m *ModelServerPopulator) GetLifecycle() string {
+	lifecycle := m.getStringPropVal(brdgtypes.Lifecycle)
+	if lifecycle != nil {
+		return *lifecycle
+	}
+	return m.Lifecycle
+}
+
+func (m *ModelServerPopulator) GetDescription() string {
+	desc := ""
+	d := m.getStringPropVal(brdgtypes.DescriptionKey)
+	if d != nil {
+		return *d
+	}
+	return desc
+}
+
+type ModelServerAPIPopulator struct {
+	CommonSchemaPopulator
+}
+
+func (m *ModelServerAPIPopulator) getStringPropVal(key string) *string {
+	return commonGetStringPropVal(key, m.InferSvc)
+}
+
+func (m *ModelServerAPIPopulator) GetSpec() string {
+	ret := m.getStringPropVal(brdgtypes.APISpecKey)
+	if ret == nil {
+		return "TBD"
+	}
+	return *ret
+}
+
+func (m *ModelServerAPIPopulator) GetTags() []string {
+	tags := []string{}
+	for k, v := range m.InferSvc.Labels {
+		tag := fmt.Sprintf("%s-%s", util.SanitizeName(k), util.SanitizeName(v))
+		tags = append(tags, util.SanitizeName(tag))
+	}
+	return tags
+}
+
+func (m *ModelServerAPIPopulator) GetType() golang.Type {
+	t := m.getStringPropVal(brdgtypes.APITypeKey)
+	if t == nil {
+		// assume open api
+		return golang.Openapi
+	}
+	switch {
+	case golang.Type(*t) == golang.Graphql:
+		return golang.Graphql
+	case golang.Type(*t) == golang.Asyncapi:
+		return golang.Asyncapi
+	case golang.Type(*t) == golang.Grpc:
+		return golang.Grpc
+	}
+	return golang.Openapi
+}
+
+func (m *ModelServerAPIPopulator) GetURL() string {
+	if m.InferSvc.Status.URL != nil && m.InferSvc.Status.URL.URL() != nil {
+		// return the KServe InferenceService Route or Service URL
+		kisUrl := m.InferSvc.Status.URL.URL().String()
+		if strings.Contains(kisUrl, "svc.cluster.local") {
+			// only the service was exposed
+
+			// prior testing with chatbot confirmed we needed to add the target port to the service URL if the port is 80
+			// and the target port is 8080; otherwise, if the port itself is 8080, the odh/rhoai consoles seem the append
+			// the port correctly; so we will find the corresponding service and add the port
+			listOptions := &client.ListOptions{Namespace: m.InferSvc.Namespace}
+			svcList := &corev1.ServiceList{}
+			err := m.CtrlClient.List(m.Ctx, svcList, listOptions)
+			if err != nil {
+				return ""
+			}
+			for _, svc := range svcList.Items {
+				if svc.OwnerReferences == nil {
+					continue
+				}
+				for _, o := range svc.OwnerReferences {
+					if o.Kind == "InferenceService" &&
+						o.Name == m.InferSvc.Name &&
+						strings.HasSuffix(svc.Name, "-predictor") {
+						// prior testing with chatbot confirmed we needed to add the target port to the service URL if the port is 80
+						// and the target port is 8080; otherwise, if the port itself is 8080, the odh/rhoai consoles seem the append
+						// the port correctly
+						var port int32
+						port = 0
+						for _, sp := range svc.Spec.Ports {
+							port = sp.Port
+							if sp.TargetPort.Type == intstr.Int {
+								port = sp.TargetPort.IntVal
+							}
+							break
+						}
+						portStr := ""
+						if port != 0 && port != 80 {
+							portStr = fmt.Sprintf(":%d", port)
+						}
+						return fmt.Sprintf("http://%s.%s.svc.cluster.local%s", svc.Name, svc.Namespace, portStr)
+					}
+				}
+			}
+
+		}
+		return m.InferSvc.Status.URL.URL().String()
+	}
+	return ""
+}
+
+type ModelPopulator struct {
+	CommonSchemaPopulator
+}
+
+func (m *ModelPopulator) GetName() string {
+	name := fmt.Sprintf("%s-%s", util.SanitizeName(m.InferSvc.Namespace), util.SanitizeName(m.InferSvc.Name))
+	return util.SanitizeName(name)
+}
+
+func (m *ModelPopulator) GetOwner() string {
+	owner := m.getStringPropVal(brdgtypes.Owner)
+	if owner != nil {
+		return util.SanitizeName(*owner)
+	}
+	return m.Owner
+}
+
+func (m *ModelPopulator) GetLifecycle() string {
+	lifecycle := m.getStringPropVal(brdgtypes.Lifecycle)
+	if lifecycle != nil {
+		return util.SanitizeName(*lifecycle)
+	}
+	return m.Lifecycle
+}
+
+func (m *ModelPopulator) GetDescription() string {
+	desc := ""
+	d := m.getStringPropVal(brdgtypes.DescriptionKey)
+	if d != nil {
+		return *d
+	}
+	return desc
+}
+
+func (m *ModelPopulator) GetTags() []string {
+	tags := []string{}
+	for k, v := range m.InferSvc.Labels {
+		tag := fmt.Sprintf("%s-%s", util.SanitizeName(k), util.SanitizeName(v))
+		tags = append(tags, util.SanitizeName(tag))
+	}
+	return tags
+}
+
+func (m *ModelPopulator) GetArtifactLocationURL() *string {
+	model := m.InferSvc.Spec.Predictor.Model
+	if model != nil && model.StorageURI != nil {
+		return model.StorageURI
+	}
+	if model != nil && model.Storage != nil && model.Storage.Path != nil {
+		url := fmt.Sprintf("s3://%s", *model.Storage.Path)
+		return &url
+	}
+	return nil
+}
+
+func (m *ModelPopulator) getStringPropVal(key string) *string {
+	return commonGetStringPropVal(key, m.InferSvc)
+}
+
+func (m *ModelPopulator) GetEthics() *string {
+	return m.getStringPropVal(brdgtypes.EthicsKey)
+}
+
+func (m *ModelPopulator) GetHowToUseURL() *string {
+	return m.getStringPropVal(brdgtypes.HowToUseKey)
+}
+
+func (m *ModelPopulator) GetSupport() *string {
+	return m.getStringPropVal(brdgtypes.SupportKey)
+}
+
+func (m *ModelPopulator) GetTraining() *string {
+	return m.getStringPropVal(brdgtypes.TrainingKey)
+}
+
+func (m *ModelPopulator) GetUsage() *string {
+	return m.getStringPropVal(brdgtypes.UsageKey)
+}
+
+func (m *ModelPopulator) GetLicense() *string {
+	return m.getStringPropVal(brdgtypes.LicenseKey)
+}
+
+func (m *ModelPopulator) GetTechDocs() *string {
+	techdocsUrl := m.getStringPropVal(brdgtypes.TechDocsKey)
+	if techdocsUrl == nil && strings.Contains(m.GetName(), brdgtypes.Granite318bLabName) {
+		granite31TechDocs := brdgtypes.Granite318bLabTechDocs
+		return &granite31TechDocs
+	} else if techdocsUrl != nil {
+		u, err := url.Parse(*techdocsUrl)
+		switch {
+		case err != nil:
+			fallthrough
+		case u == nil:
+			fallthrough
+		case u != nil && (u.Scheme != "http" && u.Scheme != "https"):
+			klog.Errorf("ignoring techdoc URL since there is either an error or bad scheme for techdoc url %v: err %v, url %v", techdocsUrl, err, u)
+			return nil
+		}
+	}
+	return techdocsUrl
+}
+
+type ModelCatalogPopulator struct {
+	CommonSchemaPopulator
+	MSPop *ModelServerPopulator
+	MPops []*ModelPopulator
+}
+
+func (m *ModelCatalogPopulator) GetModels() []golang.Model {
+	models := []golang.Model{}
+	mPop := ModelPopulator{CommonSchemaPopulator: CommonSchemaPopulator{m.ComponentPopulator}}
+	mPop.InferSvc = m.InferSvc
+	m.MPops = append(m.MPops, &mPop)
+
+	model := golang.Model{
+		ArtifactLocationURL: mPop.GetArtifactLocationURL(),
+		Description:         mPop.GetDescription(),
+		Ethics:              mPop.GetEthics(),
+		HowToUseURL:         mPop.GetHowToUseURL(),
+		Lifecycle:           mPop.GetLifecycle(),
+		Name:                mPop.GetName(),
+		Owner:               mPop.GetOwner(),
+		Support:             mPop.GetSupport(),
+		Tags:                mPop.GetTags(),
+		Training:            mPop.GetTraining(),
+		Usage:               mPop.GetUsage(),
+		License:             mPop.GetLicense(),
+	}
+
+	model.Annotations = make(map[string]string)
+	techDocsUrl := mPop.GetTechDocs()
+	if techDocsUrl != nil && *techDocsUrl != "" {
+		model.Annotations[brdgtypes.TechDocsKey] = *techDocsUrl
+	}
+	models = append(models, model)
+
+	return models
+}
+
+func (m *ModelCatalogPopulator) GetModelServer() *golang.ModelServer {
+
+	m.MSPop.InferSvc = m.InferSvc
+
+	return &golang.ModelServer{
+		API:            m.MSPop.GetAPI(),
+		Authentication: m.MSPop.GetAuthentication(),
+		Description:    m.MSPop.GetDescription(),
+		HomepageURL:    m.MSPop.GetHomepageURL(),
+		Lifecycle:      m.MSPop.GetLifecycle(),
+		Name:           m.MSPop.GetName(),
+		Owner:          m.MSPop.GetOwner(),
+		Tags:           m.MSPop.GetTags(),
+		Usage:          m.MSPop.GetUsage(),
+	}
 }

--- a/pkg/cmd/server/rhoai-normalizer/controller_test.go
+++ b/pkg/cmd/server/rhoai-normalizer/controller_test.go
@@ -9,18 +9,23 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/kubeflowmodelregistry"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
+	bridgerest "github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
 	types2 "github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/kfmr"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/location"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/storage"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"net/http/httptest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -57,14 +62,46 @@ func TestReconcile(t *testing.T) {
 		expectedValue string
 	}{
 		{
-			name: "kserve inference service without kubeflow route",
+			name: "kserve inference service that is not yet ready",
 			is: &serverapiv1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
 				Spec:       serverapiv1beta1.InferenceServiceSpec{},
 				Status:     serverapiv1beta1.InferenceServiceStatus{},
 			},
-			//TODO set expectedFound to true and check for this expectedValue with kserve-only is re-added after summit
-			//expectedValue: "KServe instance foo:bar",
+		},
+		{
+			name: "kserve inference service without kubeflow route",
+			is: &serverapiv1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+				Spec:       serverapiv1beta1.InferenceServiceSpec{},
+				Status: serverapiv1beta1.InferenceServiceStatus{
+					ModelStatus: serverapiv1beta1.ModelStatus{
+						TransitionStatus: serverapiv1beta1.UpToDate,
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{
+								Type:   bridgerest.INF_SVC_IngressReady_CONDITION,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   bridgerest.INF_SVC_PredictorReady_CONDITION,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   bridgerest.INF_SVC_Ready_CONDITION,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					URL: &apis.URL{
+						Scheme: "https",
+						Host:   "kserve.com",
+					},
+				},
+			},
+			expectedFound: true,
+			expectedValue: `"owner":"foo"`,
 		},
 		{
 			name: "kserve inference service with kubeflow route but not kubeflow inference service",
@@ -77,11 +114,35 @@ func TestReconcile(t *testing.T) {
 			is: &serverapiv1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "faa", Name: "bor"},
 				Spec:       serverapiv1beta1.InferenceServiceSpec{},
-				Status:     serverapiv1beta1.InferenceServiceStatus{},
+				Status: serverapiv1beta1.InferenceServiceStatus{
+					ModelStatus: serverapiv1beta1.ModelStatus{
+						TransitionStatus: serverapiv1beta1.UpToDate,
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							{
+								Type:   bridgerest.INF_SVC_IngressReady_CONDITION,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   bridgerest.INF_SVC_PredictorReady_CONDITION,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   bridgerest.INF_SVC_Ready_CONDITION,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					URL: &apis.URL{
+						Scheme: "https",
+						Host:   "kserve.com",
+					},
+				},
 			},
-			kfmrSvr: kts2,
-			//TODO set expectedFound to true and check for this expectedValue with kserve-only is re-added after summit
-			//expectedValue: "KServe instance faa:bor",
+			kfmrSvr:       kts2,
+			expectedFound: true,
+			expectedValue: `"owner":"faa"`,
 		},
 		{
 			name: "kserve inference service with kubeflow route and kubeflow inference service",
@@ -110,7 +171,8 @@ func TestReconcile(t *testing.T) {
 		}
 		r.client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 		r.kfmrRoute = tc.route
-		r.Reconcile(ctx, reconcile.Request{types.NamespacedName{Namespace: tc.is.Namespace, Name: tc.is.Name}})
+		result, err := r.Reconcile(ctx, reconcile.Request{types.NamespacedName{Namespace: tc.is.Namespace, Name: tc.is.Name}})
+		common.AssertError(t, err)
 		found := false
 		callback.Range(func(key, value any) bool {
 			found = true
@@ -122,6 +184,9 @@ func TestReconcile(t *testing.T) {
 			return true
 		})
 		common.AssertEqual(t, tc.expectedFound, found)
+		if !tc.expectedFound {
+			common.AssertEqual(t, result.Requeue, true)
+		}
 	}
 }
 
@@ -132,6 +197,8 @@ func TestStart(t *testing.T) {
 	defer kts1.Close()
 	kts2 := kfmr.CreateGetServer(t)
 	defer kts2.Close()
+	kts3 := kfmr.CreateEmptyGetServer(t)
+	defer kts3.Close()
 	brts := location.CreateBridgeLocationServer(t)
 	defer brts.Close()
 	callback := sync.Map{}
@@ -165,24 +232,56 @@ func TestStart(t *testing.T) {
 		{
 			name: "not deployed, only registered model, model version, model artifact",
 			is: &serverapiv1beta1.InferenceService{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "faa", Name: "bor"},
-				Spec:       serverapiv1beta1.InferenceServiceSpec{},
-				Status:     serverapiv1beta1.InferenceServiceStatus{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "faa",
+					Name:      "bor",
+					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1"},
+				},
+				Spec:   serverapiv1beta1.InferenceServiceSpec{},
+				Status: serverapiv1beta1.InferenceServiceStatus{},
 			},
 			kfmrSvr:       kts2,
-			expectedKey:   "/model-1/v1/catalog-info.yaml",
+			expectedKey:   "model-1_v1",
 			expectedValue: "description: dummy model 1",
 		},
 		{
 			name: "deployed, with inference_service and serving_environments added",
 			is: &serverapiv1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mnist-v1",
+					Namespace: "ggmtest",
+					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1"},
+				},
+				Spec:   serverapiv1beta1.InferenceServiceSpec{},
+				Status: serverapiv1beta1.InferenceServiceStatus{},
+			},
+			kfmrSvr:       kts1,
+			expectedKey:   "mnist_v1,mnist_v3",
+			expectedValue: "url: https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx",
+		},
+		{
+			name: "deployed, kserve only, no labels",
+			is: &serverapiv1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: "mnist-v1", Namespace: "ggmtest"},
 				Spec:       serverapiv1beta1.InferenceServiceSpec{},
 				Status:     serverapiv1beta1.InferenceServiceStatus{},
 			},
-			kfmrSvr:       kts1,
-			expectedKey:   "/mnist/v1/catalog-info.yaml",
-			expectedValue: "url: https://huggingface.co/tarilabs/mnist/resolve/v20231206163028/mnist.onnx",
+			kfmrSvr:     kts3,
+			expectedKey: "ggmtest_mnist-v1",
+		},
+		{
+			name: "deployed, kserve only, non kubeflow labels",
+			is: &serverapiv1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mnist-v1",
+					Namespace: "ggmtest",
+					Labels:    map[string]string{"foo": "bar"},
+				},
+				Spec:   serverapiv1beta1.InferenceServiceSpec{},
+				Status: serverapiv1beta1.InferenceServiceStatus{},
+			},
+			kfmrSvr:     kts3,
+			expectedKey: "ggmtest_mnist-v1",
 		},
 	} {
 		ctx := context.TODO()
@@ -199,18 +298,42 @@ func TestStart(t *testing.T) {
 		bwriter := bufio.NewWriter(buf)
 		r.innerStart(ctx, buf, bwriter)
 
-		found := false
-		callback.Range(func(key, value any) bool {
-			found = true
-			t.Logf(fmt.Sprintf("found key %s for test %s", key, tc.name))
-			postStr, ok := value.(string)
-			common.AssertEqual(t, ok, true)
-			common.AssertContains(t, postStr, []string{tc.expectedValue})
+		if len(tc.expectedValue) > 0 {
+			found := false
+			callback.Range(func(key, value any) bool {
+				t.Logf(fmt.Sprintf("found key %s for test %s", key, tc.name))
+				if !found {
+					postStr, ok := value.(string)
+					common.AssertEqual(t, ok, true)
+					if strings.Contains(postStr, tc.expectedValue) {
+						found = true
+						// clear out key for next test
+						callback.Delete(key)
+					}
+				}
 
-			return true
-		})
-		common.AssertEqual(t, found, true)
-		common.AssertEqual(t, true, len(buf.Bytes()) > 0)
+				return true
+			})
+			common.AssertEqual(t, found, true)
+			common.AssertEqual(t, true, len(buf.Bytes()) > 0)
+		}
+		if len(tc.expectedKey) > 0 {
+			found := false
+			callback.Range(func(key, value any) bool {
+				t.Logf(fmt.Sprintf("found key %s for test %s", key, tc.name))
+				if !found {
+					postStr, ok := value.(string)
+					common.AssertEqual(t, ok, true)
+					if strings.Contains(postStr, tc.expectedKey) {
+						found = true
+						// clear out key for next test
+						callback.Delete(key)
+					}
+				}
+				return true
+			})
+			common.AssertEqual(t, found, true)
+		}
 	}
 
 }
@@ -261,15 +384,19 @@ func TestStartArchived(t *testing.T) {
 		bwriter := bufio.NewWriter(buf)
 		r.innerStart(ctx, buf, bwriter)
 
-		found := false
+		ok := false
 		callback.Range(func(key, value any) bool {
-			found = true
+			postStr, isStr := value.(string)
+			common.AssertEqual(t, isStr, true)
+			if len(postStr) == 0 {
+				ok = true
+			}
 			t.Logf(fmt.Sprintf("found key %s value %s for test %s", key, value, tc.name))
 
 			return true
 		})
 		// callback should not have any entries since we should not have called the storage tier
-		common.AssertEqual(t, found, false)
+		common.AssertEqual(t, ok, true)
 		common.AssertEqual(t, true, len(buf.Bytes()) == 0)
 	}
 

--- a/pkg/rest/kfmr.go
+++ b/pkg/rest/kfmr.go
@@ -10,4 +10,9 @@ const (
 	GET_SERVING_ENV_URI              = "/serving_environments/%s"
 	GET_MODEL_ARTIFACT_URI           = "/model_artifacts/%s"
 	GET_MODEL_VERSION_URI            = "/model_versions/%s"
+	INF_SVC_MV_ID_LABEL              = "modelregistry.opendatahub.io/model-version-id"
+	INF_SVC_RM_ID_LABEL              = "modelregistry.opendatahub.io/registered-model-id"
+	INF_SVC_IngressReady_CONDITION   = "IngressReady"
+	INF_SVC_PredictorReady_CONDITION = "PredictorReady"
+	INF_SVC_Ready_CONDITION          = "Ready"
 )

--- a/pkg/types/normalizer.go
+++ b/pkg/types/normalizer.go
@@ -68,3 +68,8 @@ const (
 	Granite318bLabName     = "granite-31-8b-lab"
 	Granite318bLabTechDocs = "https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs/tree/main"
 )
+
+const (
+	AnnotationPrefix = "modelcatalogbridge.rhdh.io/"
+	DescriptionKey   = "description"
+)

--- a/test/stub/common/constants.go
+++ b/test/stub/common/constants.go
@@ -1585,6 +1585,8 @@ const TestJSONStringRegisteredModelOneLineGet = `{"createTimeSinceEpoch":"173110
 const (
 	TestJSONSuccessfulBackstageLocationImportReturn = `{"id":"e83bc2d8-0f1c-49f2-b65b-8bfbbbe29ae2", "target":"http://rhoai-bridge.com/mnist/v1/catalog-info.yaml", "type":"rhdh-rhoai-bridge"}`
 
+	TestJSONStringEmptyRegisteredModelOneLine = `{"items":[],"nextPageToken":"","pageSize":0,"size":0}`
+
 	TestJSONStringRegisteredModelOneLine = `{"items":[{"createTimeSinceEpoch":"1731103949567","customProperties":{"foo":{"metadataType":"MetadataStringValue","string_value":"bar"}},"description":"dummy model 1","id":"1","lastUpdateTimeSinceEpoch":"1731103975700","name":"model-1","Owner":"kube:admin","state":"LIVE"}],"nextPageToken":"","pageSize":0,"size":1}`
 
 	TestJSONStringModelVersionOneLine  = `{"items":[{"author":"kube:admin","createTimeSinceEpoch":"1731103949724","customProperties":{},"description":"version 1","id":"2","lastUpdateTimeSinceEpoch":"1731103949724","name":"v1","registeredModelId":"1","state":"LIVE"}],"nextPageToken":"","pageSize":0,"size":1}`

--- a/test/stub/kfmr/kfmr.go
+++ b/test/stub/kfmr/kfmr.go
@@ -17,6 +17,25 @@ func SetupKubeflowTestRESTClient(ts *httptest.Server, cfg *config.Config) {
 	cfg.KubeflowRESTClient = common.DC()
 }
 
+func CreateEmptyGetServer(t *testing.T) *httptest.Server {
+	ts := common.CreateTestServer(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("Method: %v", r.Method)
+		t.Logf("Path: %v", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case common.MethodGet:
+			switch {
+			case strings.HasSuffix(r.URL.Path, rest.LIST_REG_MODEL_URI):
+				_, _ = w.Write([]byte(common.TestJSONStringEmptyRegisteredModelOneLine))
+
+			}
+		}
+	})
+
+	return ts
+}
+
 func CreateGetServer(t *testing.T) *httptest.Server {
 	ts := common.CreateTestServer(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("Method: %v", r.Method)

--- a/test/stub/storage/storage.go
+++ b/test/stub/storage/storage.go
@@ -22,6 +22,7 @@ func SetupBridgeStorageRESTClient(ts *httptest.Server) *storage.BridgeStorageRES
 	storageTC.UpsertURL = ts.URL + util.UpsertURI
 	storageTC.ListURL = ts.URL + util.ListURI
 	storageTC.FetchURL = ts.URL + util.FetchURI
+	storageTC.CurrentKeySetURL = ts.URL + util.CurrentKeySetURI
 	return storageTC
 }
 
@@ -55,6 +56,18 @@ func CreateBridgeStorageREST(t *testing.T, called *sync.Map) *httptest.Server {
 			}
 		case common.MethodPost:
 			switch r.URL.Path {
+			case util.CurrentKeySetURI:
+				w.Header().Set("Content-Type", "application/json")
+				queryParams := r.URL.Query()
+				for k, v := range queryParams {
+					for _, vv := range v {
+						t.Logf("query param k %s vv %s", k, vv)
+						called.Store(k, vv)
+					}
+				}
+				_, _ = w.Write([]byte(" "))
+				w.WriteHeader(http.StatusOK)
+
 			default:
 				w.Header().Set("Content-Type", "application/json")
 				bodyBuf, err := io.ReadAll(r.Body)


### PR DESCRIPTION
as we temporarily disabled it for summit

also added annotation based k/v pair setting of various fields in our json schema, akin to the use of custom property k/v pairs with model registry

lastly added some manifests to deploy via kserve the simple 'mnist' the RHOAI team pointed us to for dev/unit test 