### PR TITLE
add some code TODO's and README tweaks to prep for adding support for multiple kubeflow model registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Either via the command line, or from your favorite Golang editor, set the follow
 
 1. `K8S_TOKEN` - the login/bearer token of your `kubeadmin` user for the OCP cluster you are testing on
 2. `KUBECONFIG` - the path to the local kubeconfig file corresponding to your OCP cluster
-3. `MR_ROUTE` - the name of the Model Registry route in the `istio-system` namespace. For now, use `odh-model-registries-modelregistry-public-rest`.
+3. `MR_ROUTE` - the name of the Model Registry route in the `istio-system` namespace. For now, use `odh-model-registries-modelregistry-public-rest`.  We will make this a comma separated list of route names in the `istio-system` namespace to allow for multiple registries.  Also, the RHOAI model registry team is looking to remove Service Mesh as a dependency in RHOAI 1.22.  This may affect where the RHOAI/Kubeflow model registry routes are stored, and how they are labeled for lookup.
 4. `NAMESPACE` - the name of the namespace you create for deploying AI models from ODH
 5. `STORAGE_URL` - for now, just use `http://localhost:7070`; this will be updated when we can run this container in OCP as part of the RHDH plugin running in RHDH
 6. `NORMALIZER_FORMAT` - can either be `JsonArrayFormat` for our new format from the `schema` folder, or the legacy `CatalogInfoYamlFormat`; if not set defaults to `CatalogInfoYamlFormat` until RHDHPAI-611 and RHDHPAI-612 are completed.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/client-go v0.31.4
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.31.4
+	knative.dev/pkg v0.0.0-20241223131119-4c901591eb4a
 	sigs.k8s.io/controller-runtime v0.19.3
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -143,7 +144,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20240827152857-f7e401e7b4c2 // indirect
 	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 // indirect
 	knative.dev/networking v0.0.0-20240815142417-37fdbdd0854b // indirect
-	knative.dev/pkg v0.0.0-20241223131119-4c901591eb4a // indirect
 	knative.dev/serving v0.42.2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect

--- a/pkg/cmd/server/rhoai-normalizer/controller.go
+++ b/pkg/cmd/server/rhoai-normalizer/controller.go
@@ -246,13 +246,15 @@ func (f RHOAINormalizerFilter) Update(e event.UpdateEvent) bool {
 }
 
 type RHOAINormalizerReconcile struct {
-	client           client.Client
-	scheme           *runtime.Scheme
-	eventRecorder    record.EventRecorder
-	k8sToken         string
-	kfmrRoute        *routev1.Route
-	myNS             string
-	routeClient      *routeclient.RouteV1Client
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
+	k8sToken      string
+	//TODO make array to handle multi-registry
+	kfmrRoute   *routev1.Route
+	myNS        string
+	routeClient *routeclient.RouteV1Client
+	//TODO make array to handle multi-registry
 	kfmr             *kubeflowmodelregistry.KubeFlowRESTClientWrapper
 	storage          *storage.BridgeStorageRESTClient
 	format           types2.NormalizerFormat
@@ -380,6 +382,7 @@ func (r *RHOAINormalizerReconcile) processKFMR(ctx context.Context, name types.N
 	}
 
 	var kfmrISs []openapi.InferenceService
+	//TODO as part of multi-registry support, need to iterator over all the model registries we are aware of to see which one deployed the KServe InferenceService, adding to the kfmrISs array
 	kfmrISs, err = r.kfmr.ListInferenceServices()
 	if err != nil {
 		log.Error(err, fmt.Sprintf("reconciling inferenceservice %s, error listing kfmr registered models", name.String()))
@@ -531,7 +534,7 @@ func (r *RHOAINormalizerReconcile) innerStart(ctx context.Context, buf *bytes.Bu
 	var mas map[string]map[string][]openapi.ModelArtifact
 	var isl []openapi.InferenceService
 
-	//TODO what do we do with owner/lifecycle when we poll
+	//TODO when we officially do multi model registry, the `r.kfmr` field will be an array, and we'll aggregate each model registry's output into what we process below.
 	rms, mvs, mas, err = kubeflowmodelregistry.LoopOverKFMR([]string{}, r.kfmr)
 	if err != nil {
 		controllerLog.Error(err, "err looping over KFMR")


### PR DESCRIPTION
based on the conversations with the devhub.corp.redhat.com folks, where they asked about supporting multiple registries, instead of creating multiple instances of the bridge to work with each kubeflow model registry instance, here is a quick set of `TODO` markers of what I think is needed (minus associated unit test changes) to support multiple model registries from a single bridge instance

@johnmcollier @thepetk @elsony fyi / ptal