### PR TITLE
make various bridge ports configurable via go argument flags

### DIFF
--- a/cmd/location/main.go
+++ b/cmd/location/main.go
@@ -12,8 +12,12 @@ import (
 )
 
 func main() {
+	var address string
+	goflag.StringVar(&address, "address", "9090", "The port the location service listens on.")
 	flagset := goflag.NewFlagSet("location", goflag.ContinueOnError)
+	flagset.Parse(goflag.CommandLine.Args())
 	klog.InitFlags(flagset)
+	goflag.Parse()
 
 	st := os.Getenv(types.StorageUrlEnvVar)
 	rr := strings.NewReplacer("\r", "", "\n", "")
@@ -30,7 +34,7 @@ func main() {
 	if len(nfstr) == 0 {
 		nf = types.JsonArrayForamt
 	}
-	server := gin_gonic_http_srv.NewImportLocationServer(st, nf)
+	server := gin_gonic_http_srv.NewImportLocationServer(st, address, nf)
 	stopCh := util.SetupSignalHandler()
 	server.Run(stopCh)
 

--- a/cmd/rhoai-normalizer/main.go
+++ b/cmd/rhoai-normalizer/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	metrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 var (
@@ -22,7 +23,9 @@ var (
 
 func main() {
 	var pprofAddr string
+	var metricsAddr string
 	flag.StringVar(&pprofAddr, "pprof-address", "6000", "The address the pprof endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-address", metrics.DefaultBindAddress, "The address the metrics server endpoint binds to.")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -48,6 +51,7 @@ func main() {
 	restConfig.Burst = 50
 	var mgr ctrl.Manager
 	mopts := ctrl.Options{}
+	mopts.Metrics.BindAddress = metricsAddr
 
 	mgr, err = rhoai_normalizer.NewControllerManager(ctx, restConfig, mopts, pprofAddr)
 	if err != nil {

--- a/cmd/storage-rest/main.go
+++ b/cmd/storage-rest/main.go
@@ -12,8 +12,12 @@ import (
 )
 
 func main() {
+	var address string
+	goflag.StringVar(&address, "address", "7070", "The port the storage service listens on.")
 	flagset := goflag.NewFlagSet("storage-rest", goflag.ContinueOnError)
+	flagset.Parse(goflag.CommandLine.Args())
 	klog.InitFlags(flagset)
+	goflag.Parse()
 
 	st := os.Getenv(types.StorageTypeEnvVar)
 	storageType := types.BridgeStorageType(st)
@@ -50,7 +54,7 @@ func main() {
 	nfstr := os.Getenv(types.FormatEnvVar)
 	nf := types.NormalizerFormat(nfstr)
 
-	server := storage.NewStorageRESTServer(bs, bridgeURL, bridgeToken, bkstgToken, nf)
+	server := storage.NewStorageRESTServer(bs, address, bridgeURL, bridgeToken, bkstgToken, nf)
 	stopCh := util.SetupSignalHandler()
 	server.Run(stopCh)
 

--- a/pkg/cmd/server/location/server/server.go
+++ b/pkg/cmd/server/location/server/server.go
@@ -20,9 +20,10 @@ type ImportLocationServer struct {
 	content map[string]*ImportLocation
 	storage *storage.BridgeStorageRESTClient
 	format  types.NormalizerFormat
+	port    string
 }
 
-func NewImportLocationServer(stURL string, nf types.NormalizerFormat) *ImportLocationServer {
+func NewImportLocationServer(stURL, port string, nf types.NormalizerFormat) *ImportLocationServer {
 	//var content map[string]*ImportLocation
 	gin.SetMode(gin.ReleaseMode)
 	cfg, _ := util.GetK8sConfig(&config.Config{})
@@ -32,6 +33,7 @@ func NewImportLocationServer(stURL string, nf types.NormalizerFormat) *ImportLoc
 		content: map[string]*ImportLocation{},
 		storage: storage.SetupBridgeStorageRESTClient(stURL, util.GetCurrentToken(cfg)),
 		format:  nf,
+		port:    port,
 	}
 	r.SetTrustedProxies(nil)
 	r.TrustedPlatform = "X-Forwarded-For"
@@ -106,7 +108,7 @@ func (i *ImportLocationServer) Run(stopCh <-chan struct{}) {
 			case <-ch:
 				return
 			default:
-				err := i.router.Run(":9090")
+				err := i.router.Run(fmt.Sprintf(":%s", i.port))
 				if err != nil {
 					klog.Errorf("ERROR: gin-gonic run error %s", err.Error())
 				}

--- a/pkg/cmd/server/storage/server.go
+++ b/pkg/cmd/server/storage/server.go
@@ -33,9 +33,10 @@ type StorageRESTServer struct {
 	bkstgToken      string
 	format          types.NormalizerFormat
 	pushToRHDH      bool
+	port            string
 }
 
-func NewStorageRESTServer(st types.BridgeStorage, bridgeURL, bridgeToken, bkstgToken string, nf types.NormalizerFormat) *StorageRESTServer {
+func NewStorageRESTServer(st types.BridgeStorage, port, bridgeURL, bridgeToken, bkstgToken string, nf types.NormalizerFormat) *StorageRESTServer {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 	pushToRHDH := true
@@ -53,6 +54,7 @@ func NewStorageRESTServer(st types.BridgeStorage, bridgeURL, bridgeToken, bkstgT
 		bkstgToken:      bkstgToken,
 		format:          nf,
 		pushToRHDH:      pushToRHDH,
+		port:            port,
 	}
 	s.setupBkstg()
 	klog.Infof("NewStorageRESTServer")
@@ -84,7 +86,7 @@ func (s *StorageRESTServer) Run(stopCh <-chan struct{}) {
 			case <-ch:
 				return
 			default:
-				err := s.router.Run(":7070")
+				err := s.router.Run(fmt.Sprintf(":%s", s.port))
 				if err != nil {
 					klog.Errorf("ERROR: gin-gonic run error %s", err.Error())
 				}


### PR DESCRIPTION
    - controller-runtime metric port
    - location svc REST interface port
    - storage svc  REST interface port


verified via our local dev setup

using the flag 

```
-metrics-address=":8888"
```

now when I start up the normalizer the controller runtime listens on port `8888`

```
$ sudo lsof -nP -iTCP -sTCP:LISTEN | grep 8888
___go_bui 45095        gmontero    7u  IPv6 207092      0t0  TCP *:8888 (LISTEN)
$
```

similar verifies with location/storage svc