### PR TITLE
RHDHPAI-1124: fix kserve/kubeflow inferenceservice correlation; fix kubeflow ModelVersion / bridge ModelCatalog/Models correlation

### DIFF
--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -298,7 +298,7 @@ func (m *ModelCatalogPopulator) GetModelServer() *golang.ModelServer {
 			m.Kis != nil, mv.RegisteredModelId == m.RegisteredModel.GetId(), mv.GetId() == kfmrIS.GetModelVersionId(), mv.RegisteredModelId == m.RegisteredModel.GetId(), mv.GetId() == kfmrIS.GetModelVersionId())
 		switch {
 		// in case kubeflow/kserve reconciliation is not working
-		case m.Kis != nil && util.KServeInferenceServiceMapping(m.RegisteredModel.Name, mv.GetName(), m.Kis.Name):
+		case m.Kis != nil && util.KServeInferenceServiceMapping(m.RegisteredModel.GetId(), mv.GetId(), m.Kis):
 			fallthrough
 		case mv.RegisteredModelId == m.RegisteredModel.GetId() && mv.GetId() == kfmrIS.GetModelVersionId():
 			foundInferenceService = true
@@ -902,7 +902,7 @@ func (pop *CommonPopulator) GetInferenceServerByRegModelModelVersionName() *serv
 	klog.V(4).Infof("commonPop:GetInferenceServerByRegModelModelVersionName found %d kserve infsvcs with %d modelvers", len(iss), len(pop.ModelVersions))
 	for _, mv := range pop.ModelVersions {
 		for _, is := range iss {
-			if util.KServeInferenceServiceMapping(pop.RegisteredModel.Name, mv.Name, is.Name) {
+			if util.KServeInferenceServiceMapping(pop.RegisteredModel.GetId(), mv.GetId(), &is) {
 				return &is
 			}
 		}

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
@@ -158,8 +158,10 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 			maa, ok2 := mas[util.SanitizeName(rm.Name)]
 			common.AssertEqual(t, true, ok2)
 			isl, _ := k.ListInferenceServices()
-			err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, mva, maa, isl, tc.is, k, cl, bwriter, types.JsonArrayForamt)
-			common.AssertError(t, err)
+			for _, is := range isl {
+				err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, mva, maa, &is, tc.is, k, cl, bwriter, types.JsonArrayForamt)
+				common.AssertError(t, err)
+			}
 			bwriter.Flush()
 			// so the order of the tags array is random so we can't just do json as a string compare, so we have to
 			// hydrate back to a &golang.ModelCatalog to compare fields
@@ -333,8 +335,10 @@ func TestLoopOverKRMR_JsonArrayMultiModel(t *testing.T) {
 			b := []byte{}
 			buf := bytes.NewBuffer(b)
 			bwriter := bufio.NewWriter(buf)
-			err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, mva, maa, isl, tc.is, k, cl, bwriter, types.JsonArrayForamt)
-			common.AssertError(t, err)
+			for _, is := range isl {
+				err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, mva, maa, &is, tc.is, k, cl, bwriter, types.JsonArrayForamt)
+				common.AssertError(t, err)
+			}
 			bwriter.Flush()
 			testMc, ok := tc.outMc[rm.GetId()]
 			common.AssertEqual(t, true, ok)
@@ -401,8 +405,10 @@ func TestLoopOverKFMR_CatalogInfoYaml(t *testing.T) {
 			maa, ok2 := mas[util.SanitizeName(rm.Name)]
 			common.AssertEqual(t, true, ok2)
 			isl, _ := k.ListInferenceServices()
-			err = CallBackstagePrinters(context.TODO(), owner, lifecycle, &rm, mva, maa, isl, nil, k, nil, bwriter, types.CatalogInfoYamlFormat)
-			common.AssertError(t, err)
+			for _, is := range isl {
+				err = CallBackstagePrinters(context.TODO(), owner, lifecycle, &rm, mva, maa, &is, nil, k, nil, bwriter, types.CatalogInfoYamlFormat)
+				common.AssertError(t, err)
+			}
 		}
 		bwriter.Flush()
 		outstr := buf.String()

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	serverapiv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kubeflow/model-registry/pkg/openapi"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/util"
@@ -37,88 +38,100 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 	defer ts.Close()
 	for _, tc := range []struct {
 		// we do output compare in chunks as ranges over the components status map are non-deterministic wrt order
-		outMc *golang.ModelCatalog
+		name  string
+		outMc []golang.ModelCatalog
 		is    *serverapiv1beta1.InferenceService
 	}{
 		{
-			outMc: &golang.ModelCatalog{
-				Models: []golang.Model{
-					{
-						Description: "simple model that does not require a GPU",
-						Ethics:      &ethics,
-						HowToUseURL: &howTo,
-						Lifecycle:   util.DefaultLifecycle,
-						Name:        "mnist-v1",
-						Owner:       "kubeadmin",
-						Support:     &support,
-						Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
-						Training:    &training,
-						License:     &license,
-						Usage:       &usage,
+			name: "2 model catalogs, neither with a model server",
+			outMc: []golang.ModelCatalog{
+				{
+					Models: []golang.Model{
+						{
+							Description: "\nsimple model that does not require a GPU",
+							Ethics:      &ethics,
+							HowToUseURL: &howTo,
+							Lifecycle:   util.DefaultLifecycle,
+							Name:        "mnist-v1",
+							Owner:       "kubeadmin",
+							Support:     &support,
+							Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
+							Training:    &training,
+							License:     &license,
+							Usage:       &usage,
+						},
 					},
-					{
-						Description: "simple model that does not require a GPU",
-						Ethics:      &ethics,
-						HowToUseURL: &howTo,
-						Lifecycle:   util.DefaultLifecycle,
-						Name:        "mnist-v3",
-						Owner:       "kubeadmin",
-						Support:     &support,
-						Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v3", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
-						Training:    &training,
-						Usage:       &usage,
+				},
+				{
+					Models: []golang.Model{
+						{
+							Description: "\nsimple model that does not require a GPU",
+							Ethics:      &ethics,
+							HowToUseURL: &howTo,
+							Lifecycle:   util.DefaultLifecycle,
+							Name:        "mnist-v3",
+							Owner:       "kubeadmin",
+							Support:     &support,
+							Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v3", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
+							Training:    &training,
+							Usage:       &usage,
+						},
 					},
 				},
 			},
 		},
 		{
-			outMc: &golang.ModelCatalog{
-				Models: []golang.Model{
-					{
-						Annotations: map[string]string{
-							"TechDocs": "http://localhost:9090/modelcard?key=RedHatrhelai1granite-7b-starter",
+			name: "2 model catalogs, 1 has as model server",
+			outMc: []golang.ModelCatalog{
+				{
+					Models: []golang.Model{
+						{
+							Description: "\nsimple model that does not require a GPU",
+							Ethics:      &ethics,
+							HowToUseURL: &howTo,
+							Lifecycle:   util.DefaultLifecycle,
+							Name:        "mnist-v1",
+							Owner:       "kubeadmin",
+							Support:     &support,
+							Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
+							Training:    &training,
+							License:     &license,
+							Usage:       &usage,
 						},
-						Description: "simple model that does not require a GPU",
-						Ethics:      &ethics,
-						HowToUseURL: &howTo,
-						Lifecycle:   util.DefaultLifecycle,
-						Name:        "mnist-v1",
-						Owner:       "kubeadmin",
-						Support:     &support,
-						Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
-						Training:    &training,
-						Usage:       &usage,
-						License:     &license,
 					},
-					{
-						Description: "simple model that does not require a GPU",
-						Ethics:      &ethics,
-						HowToUseURL: &howTo,
-						Lifecycle:   util.DefaultLifecycle,
-						Name:        "mnist-v3",
-						Owner:       "kubeadmin",
-						Support:     &support,
-						Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v3", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
-						Training:    &training,
-						Usage:       &usage,
+					ModelServer: &golang.ModelServer{
+						API: &golang.API{
+							Annotations: nil,
+							Spec:        "a openapi spec string",
+							Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "last-modified-time-2025-02-25-19-45-29-959", "grpc"},
+							Type:        golang.Grpc,
+							URL:         "https://kserve.com",
+						},
+						Authentication: &falsePtr,
+						Description:    "\nsimple model that does not require a GPU",
+						HomepageURL:    &homepageURL,
+						Lifecycle:      util.DefaultLifecycle,
+						Name:           "mnist-v18c2c357f-bf82-4d2d-a254-43eca96fd31d",
+						Owner:          "kubeadmin",
+						Tags:           []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "last-modified-time-2025-02-25-19-45-29-959", "grpc"},
+						Usage:          &usage,
 					},
 				},
-				ModelServer: &golang.ModelServer{
-					API: &golang.API{
-						Annotations: nil,
-						Spec:        "a openapi spec string",
-						Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "last-modified-time-2025-02-25-19-45-29-959", "grpc"},
-						Type:        golang.Grpc,
-						URL:         "https://kserve.com",
+				{
+					Models: []golang.Model{
+						{
+							Description: "\nsimple model that does not require a GPU",
+							Ethics:      &ethics,
+							HowToUseURL: &howTo,
+							Lifecycle:   util.DefaultLifecycle,
+							Name:        "mnist-v3",
+							Owner:       "kubeadmin",
+							Support:     &support,
+							Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v3", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
+							Training:    &training,
+							Usage:       &usage,
+						},
 					},
-					Authentication: &falsePtr,
-					Description:    "simple model that does not require a GPU",
-					HomepageURL:    &homepageURL,
-					Lifecycle:      util.DefaultLifecycle,
-					Name:           "mnist-v18c2c357f-bf82-4d2d-a254-43eca96fd31d",
-					Owner:          "kubeadmin",
-					Tags:           []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v1", "last-modified-time-2025-02-25-19-45-29-959", "grpc"},
-					Usage:          &usage,
 				},
 			},
 			is: &serverapiv1beta1.InferenceService{
@@ -139,9 +152,6 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 		kfmr.SetupKubeflowTestRESTClient(ts, cfg)
 		k := SetupKubeflowRESTClient(cfg)
 		ids := []string{}
-		b := []byte{}
-		buf := bytes.NewBuffer(b)
-		bwriter := bufio.NewWriter(buf)
 		var cl client.Client
 		if tc.is != nil {
 			objs := []client.Object{tc.is}
@@ -157,103 +167,276 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 			common.AssertEqual(t, true, ok)
 			maa, ok2 := mas[util.SanitizeName(rm.Name)]
 			common.AssertEqual(t, true, ok2)
-			isl, _ := k.ListInferenceServices()
-			for _, is := range isl {
-				err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, mva, maa, &is, tc.is, k, cl, bwriter, types.JsonArrayForamt)
+			for _, mv := range mva {
+				mvISL := []openapi.InferenceService{}
+				mvISL, err = GetKubeFlowInferenceServicesForModelVersion(k, &mv)
+				if err != nil {
+					t.Logf("GetKubeFlowInferenceServicesForModelVersion err %s", err.Error())
+					continue
+				}
+				b := []byte{}
+				buf := bytes.NewBuffer(b)
+				bwriter := bufio.NewWriter(buf)
+				if len(mvISL) == 0 {
+					err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, &mv, maa[mv.Name], nil, tc.is, k, cl, bwriter, types.JsonArrayForamt)
+				} else {
+					err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, &mv, maa[mv.Name], &mvISL[0], tc.is, k, cl, bwriter, types.JsonArrayForamt)
+				}
+				if err != nil {
+					t.Logf("CallBackstagePrinters err %s", err.Error())
+					continue
+				}
+				bwriter.Flush()
+				// so the order of the tags array is random so we can't just do json as a string compare, so we have to
+				// hydrate back to a &golang.ModelCatalog to compare fields
+				outMc := &golang.ModelCatalog{}
+				err = json.Unmarshal(buf.Bytes(), outMc)
 				common.AssertError(t, err)
-			}
-			bwriter.Flush()
-			// so the order of the tags array is random so we can't just do json as a string compare, so we have to
-			// hydrate back to a &golang.ModelCatalog to compare fields
-			outMc := &golang.ModelCatalog{}
-			err = json.Unmarshal(buf.Bytes(), outMc)
-			common.AssertError(t, err)
-			common.AssertEqual(t, tc.outMc.ModelServer == nil, outMc.ModelServer == nil)
-			common.AssertEqual(t, tc.outMc.Models == nil, outMc.Models == nil)
-			common.AssertEqual(t, len(tc.outMc.Models), len(outMc.Models))
-			if len(tc.outMc.Models) > 0 {
-				tcModel := tc.outMc.Models[0]
-				outModel := outMc.Models[0]
-				common.AssertEqual(t, tcModel.Name, outModel.Name)
-				common.AssertEqual(t, tcModel.Description, outModel.Description)
-				common.AssertEqual(t, tcModel.Lifecycle, outModel.Lifecycle)
-				common.AssertEqual(t, tcModel.Owner, outModel.Owner)
-				common.AssertEqual(t, len(tcModel.Tags), len(outModel.Tags))
-				for _, tag := range tcModel.Tags {
-					found := false
-					for _, otag := range outModel.Tags {
-						if otag == tag {
-							found = true
-							break
+				found := false
+				idx := 0
+				for oidx, omc := range tc.outMc {
+					idx = oidx
+					tcModelServer := omc.ModelServer == nil
+					outModelServer := outMc.ModelServer == nil
+					if tcModelServer != outModelServer {
+						t.Logf("model server diff oidx %d", oidx)
+						continue
+					}
+					tcModels := omc.Models == nil
+					outModels := outMc.Models == nil
+					if tcModels != outModels {
+						t.Logf("models diff nil check oidx %d", oidx)
+						continue
+					}
+					if len(omc.Models) != len(outMc.Models) {
+						t.Logf("models diff len oidx %d", oidx)
+						continue
+					}
+					if len(omc.Models) > 0 {
+						if len(outMc.Models) == 0 {
+							t.Logf("models length mismatch oidx %d", oidx)
+							continue
+						}
+						tcModel := omc.Models[0]
+						outModel := outMc.Models[0]
+						if tcModel.Name != outModel.Name {
+							t.Logf("name mismatch oidx %d", oidx)
+							continue
+						}
+						if tcModel.Description != outModel.Description {
+							t.Logf("description mismatch oidx %d", oidx)
+							continue
+						}
+						if tcModel.Lifecycle != outModel.Lifecycle {
+							t.Logf("lifecycle mismatch oidx %d", oidx)
+							continue
+						}
+						if tcModel.Owner != outModel.Owner {
+							t.Logf("owner mismatch oidx %d", oidx)
+							continue
+						}
+						if len(tcModel.Tags) != len(outModel.Tags) {
+							t.Logf("tags len mismatch oidx %d", oidx)
+							continue
+						}
+						for _, tag := range tcModel.Tags {
+							tagFound := false
+							for _, otag := range outModel.Tags {
+								if otag == tag {
+									tagFound = true
+									break
+								}
+							}
+							if !tagFound {
+								t.Logf("tag %s not found oidx %d", tag, oidx)
+								continue
+							}
+						}
+						tcEthics := tcModel.Ethics == nil
+						outEthics := outModel.Ethics == nil
+						if tcEthics != outEthics {
+							t.Logf("ethics nil mismatch oidx %d", oidx)
+							continue
+						}
+						tcHowToUseURL := tcModel.HowToUseURL == nil
+						outHowToUseURL := outModel.HowToUseURL == nil
+						if tcHowToUseURL != outHowToUseURL {
+							t.Logf("howToUseURL nil mismatch oidx %d", oidx)
+							continue
+						}
+						tcSupport := tcModel.Support == nil
+						outSupport := outModel.Support == nil
+						if tcSupport != outSupport {
+							t.Logf("support nil mismatch oidx %d", oidx)
+							continue
+						}
+						tcTraining := tcModel.Training == nil
+						outTraining := outModel.Training == nil
+						if tcTraining != outTraining {
+							t.Logf("training nil mismatch oidx %d", oidx)
+							continue
+						}
+						tcLicense := tcModel.License == nil
+						outLicense := outModel.License == nil
+						if tcLicense != outLicense {
+							t.Logf("license nil mismatch oidx %d", oidx)
+							continue
+						}
+						tcUsage := tcModel.Usage == nil
+						outUsage := outModel.Usage == nil
+						if tcUsage != outUsage {
+							t.Logf("usage nil mismatch oidx %d", oidx)
+							continue
+						}
+
+						if tcModel.Ethics != nil {
+							if *(tcModel.Ethics) != *(outModel.Ethics) {
+								t.Logf("ethics mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tcModel.HowToUseURL != nil {
+							if *(tcModel.HowToUseURL) != *(outModel.HowToUseURL) {
+								t.Logf("howToUseURL mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tcModel.Support != nil {
+							if *(tcModel.Support) != *(outModel.Support) {
+								t.Logf("support mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tcModel.Training != nil {
+							if *(tcModel.Training) != *(outModel.Training) {
+								t.Logf("training mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tcModel.Usage != nil {
+							if *(tcModel.Usage) != *(outModel.Usage) {
+								t.Logf("usage mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tcModel.License != nil {
+							if *(tcModel.License) != *(outModel.License) {
+								t.Logf("license mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tcModel.Annotations != nil {
+							if tcModel.Annotations[types.TechDocsKey] != outModel.Annotations[types.TechDocsKey] {
+								t.Logf("annotation mismatch oidx %d", oidx)
+								continue
+							}
 						}
 					}
-					common.AssertEqual(t, true, found)
-				}
-				common.AssertEqual(t, tcModel.Ethics == nil, outModel.Ethics == nil)
-				common.AssertEqual(t, tcModel.HowToUseURL == nil, outModel.HowToUseURL == nil)
-				common.AssertEqual(t, tcModel.Support == nil, outModel.Support == nil)
-				common.AssertEqual(t, tcModel.Training == nil, outModel.Training == nil)
-				common.AssertEqual(t, tcModel.License == nil, outModel.License == nil)
-				common.AssertEqual(t, tcModel.Usage == nil, outModel.Usage == nil)
-				if tcModel.Ethics != nil {
-					common.AssertEqual(t, *(tcModel.Ethics), *(outModel.Ethics))
-				}
-				if tcModel.HowToUseURL != nil {
-					common.AssertEqual(t, *(tcModel.HowToUseURL), *(outModel.HowToUseURL))
-				}
-				if tcModel.Support != nil {
-					common.AssertEqual(t, *(tcModel.Support), *(outModel.Support))
-				}
-				if tcModel.Training != nil {
-					common.AssertEqual(t, *(tcModel.Training), *(outModel.Training))
-				}
-				if tcModel.Usage != nil {
-					common.AssertEqual(t, *(tcModel.Usage), *(outModel.Usage))
-				}
-				if tcModel.License != nil {
-					common.AssertEqual(t, *(tcModel.License), *(outModel.License))
-				}
-				if tcModel.Annotations != nil {
-					common.AssertEqual(t, tcModel.Annotations[types.TechDocsKey], outModel.Annotations[types.TechDocsKey])
-				}
-			}
-			if tc.outMc.ModelServer != nil {
-				tms := tc.outMc.ModelServer
-				oms := outMc.ModelServer
-				common.AssertEqual(t, tms.Name, oms.Name)
-				common.AssertEqual(t, tms.Description, oms.Description)
-				common.AssertEqual(t, tms.Lifecycle, oms.Lifecycle)
-				common.AssertEqual(t, tms.Owner, oms.Owner)
-				common.AssertEqual(t, tms.API == nil, oms.API == nil)
-				common.AssertEqual(t, tms.Authentication == nil, oms.Authentication == nil)
-				common.AssertEqual(t, tms.HomepageURL == nil, oms.HomepageURL == nil)
-				common.AssertEqual(t, tms.Usage == nil, oms.Usage == nil)
-				common.AssertEqual(t, len(tms.Tags), len(oms.Tags))
-				if tms.API != nil {
-					common.AssertEqual(t, tms.API.Spec, oms.API.Spec)
-					common.AssertEqual(t, tms.API.URL, oms.API.URL)
-					common.AssertEqual(t, tms.API.Type, oms.API.Type)
-					common.AssertEqual(t, len(tms.API.Tags), len(oms.API.Tags))
-				}
-				if tms.Authentication != nil {
-					common.AssertEqual(t, *(tms.Authentication), *(oms.Authentication))
-				}
-				if tms.HomepageURL != nil {
-					common.AssertEqual(t, *(tms.HomepageURL), *(oms.HomepageURL))
-				}
-				if tms.Usage != nil {
-					common.AssertEqual(t, *(tms.Usage), *(oms.Usage))
-				}
-				for _, tag := range tms.Tags {
-					found := false
-					for _, otag := range oms.Tags {
-						if tag == otag {
-							found = true
-							break
+					if omc.ModelServer != nil {
+						tms := omc.ModelServer
+						oms := outMc.ModelServer
+						if tms.Name != oms.Name {
+							t.Logf("svr name mismatch oidx %d", oidx)
+							continue
+						}
+						if tms.Description != oms.Description {
+							t.Logf("svr description mismatch oidx %d", oidx)
+							continue
+						}
+						if tms.Lifecycle != oms.Lifecycle {
+							t.Logf("svr lifecycle mismatch oidx %d", oidx)
+							continue
+						}
+						if tms.Owner != oms.Owner {
+							t.Logf("svr owner mismatch oidx %d", oidx)
+							continue
+						}
+						tmsAPI := tms.API == nil
+						omsAPI := oms.API == nil
+						if tmsAPI != omsAPI {
+							t.Logf("svr api nil mismatch oidx %d", oidx)
+							continue
+						}
+						tmsAuth := tms.Authentication == nil
+						omsAuth := oms.Authentication == nil
+						if tmsAuth != omsAuth {
+							t.Logf("svr auth nil mismatch oidx %d", oidx)
+							continue
+						}
+						tmsHomepage := tms.HomepageURL == nil
+						omsHomepage := oms.HomepageURL == nil
+						if tmsHomepage != omsHomepage {
+							t.Logf("svr homepage nil mismatch oidx %d", oidx)
+							continue
+						}
+						tmsUsage := tms.Usage == nil
+						omsUsage := oms.Usage == nil
+						if tmsUsage != omsUsage {
+							t.Logf("svr usage nil mismatch oidx %d", oidx)
+							continue
+						}
+						if len(oms.Tags) != len(tms.Tags) {
+							t.Logf("svr tags len mismatch oidx %d", oidx)
+							continue
+						}
+						if tms.API != nil {
+							if tms.API.Spec != oms.API.Spec {
+								t.Logf("svr api spec mismatch oidx %d", oidx)
+								continue
+							}
+							if tms.API.URL != oms.API.URL {
+								t.Logf("svr api url mismatch oidx %d", oidx)
+								continue
+							}
+							if tms.API.Type != oms.API.Type {
+								t.Logf("svr api type mismatch oidx %d", oidx)
+								continue
+							}
+							if len(oms.API.Tags) != len(tms.API.Tags) {
+								t.Logf("svr api tags len mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tms.Authentication != nil {
+							if *(tms.Authentication) != *(oms.Authentication) {
+								t.Logf("svr authentication mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tms.HomepageURL != nil {
+							if *(tms.HomepageURL) != *(oms.HomepageURL) {
+								t.Logf("svr homepage url mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						if tms.Usage != nil {
+							if *(tms.Usage) != *(oms.Usage) {
+								t.Logf("svr usage mismatch oidx %d", oidx)
+								continue
+							}
+						}
+						for _, tag := range tms.Tags {
+							foundTag := false
+							for _, otag := range oms.Tags {
+								if tag == otag {
+									foundTag = true
+									break
+								}
+							}
+							if !foundTag {
+								t.Logf("sbr tag %s mismatch oidx %d", tag, oidx)
+								continue
+							}
 						}
 					}
-					common.AssertEqual(t, true, found)
+					found = true
+					t.Logf("FOUND MATCH %s idx %d", tc.name, oidx)
+					break
 				}
+				if !found {
+					t.Errorf("did not find match for test %s idx %d and model catalog %#v", tc.name, idx, outMc)
+				}
+
 			}
 		}
 
@@ -335,9 +518,11 @@ func TestLoopOverKRMR_JsonArrayMultiModel(t *testing.T) {
 			b := []byte{}
 			buf := bytes.NewBuffer(b)
 			bwriter := bufio.NewWriter(buf)
-			for _, is := range isl {
-				err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, mva, maa, &is, tc.is, k, cl, bwriter, types.JsonArrayForamt)
-				common.AssertError(t, err)
+			for _, mv := range mva {
+				for _, is := range isl {
+					err = CallBackstagePrinters(context.TODO(), util.DefaultOwner, util.DefaultLifecycle, &rm, &mv, maa[mv.Name], &is, tc.is, k, cl, bwriter, types.JsonArrayForamt)
+					common.AssertError(t, err)
+				}
 			}
 			bwriter.Flush()
 			testMc, ok := tc.outMc[rm.GetId()]
@@ -405,9 +590,11 @@ func TestLoopOverKFMR_CatalogInfoYaml(t *testing.T) {
 			maa, ok2 := mas[util.SanitizeName(rm.Name)]
 			common.AssertEqual(t, true, ok2)
 			isl, _ := k.ListInferenceServices()
-			for _, is := range isl {
-				err = CallBackstagePrinters(context.TODO(), owner, lifecycle, &rm, mva, maa, &is, nil, k, nil, bwriter, types.CatalogInfoYamlFormat)
-				common.AssertError(t, err)
+			for _, mv := range mva {
+				for _, is := range isl {
+					err = CallBackstagePrinters(context.TODO(), owner, lifecycle, &rm, &mv, maa[mv.Name], &is, nil, k, nil, bwriter, types.CatalogInfoYamlFormat)
+					common.AssertError(t, err)
+				}
 			}
 		}
 		bwriter.Flush()

--- a/pkg/cmd/server/rhoai-normalizer/controller.go
+++ b/pkg/cmd/server/rhoai-normalizer/controller.go
@@ -472,7 +472,7 @@ func (r *RHOAINormalizerReconcile) processKFMR(ctx context.Context, name types.N
 				}
 				klog.V(4).Infof("processKFMR num model versions %d with model registry %s and registered model %s", len(mvs), k, rm.GetId())
 				for _, mv := range mvs {
-					if util.KServeInferenceServiceMapping(rm.Name, mv.Name, is.Name) {
+					if util.KServeInferenceServiceMapping(rm.GetId(), mv.GetId(), is) {
 						// let's go with this one
 						var mas []openapi.ModelArtifact
 						mas, err = kfmr.ListModelArtifacts(mv.GetId())

--- a/pkg/cmd/server/rhoai-normalizer/controller_test.go
+++ b/pkg/cmd/server/rhoai-normalizer/controller_test.go
@@ -444,9 +444,9 @@ func TestStart_JsonArray_MultiVersion(t *testing.T) {
 			name: "deployed with multiple registries, with inference_service and serving_environments added, but also not deployed, only registered model, model version, model artifact",
 			is: &serverapiv1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mnist-v1",
+					Name:      "mnist-v1-random-suffix",
 					Namespace: "ggmtest",
-					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1"},
+					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1", bridgerest.INF_SVC_MV_ID_LABEL: "2"},
 				},
 				Spec: serverapiv1beta1.InferenceServiceSpec{},
 				Status: serverapiv1beta1.InferenceServiceStatus{

--- a/pkg/cmd/server/rhoai-normalizer/controller_test.go
+++ b/pkg/cmd/server/rhoai-normalizer/controller_test.go
@@ -270,7 +270,7 @@ func TestStart(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "faa",
 					Name:      "bor",
-					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1"},
+					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1", bridgerest.INF_SVC_MV_ID_LABEL: "2", bridgerest.INF_SVC_INF_SVC_ID_LABEL: "4"},
 				},
 				Spec:   serverapiv1beta1.InferenceServiceSpec{},
 				Status: serverapiv1beta1.InferenceServiceStatus{},
@@ -285,7 +285,7 @@ func TestStart(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mnist-v1",
 					Namespace: "ggmtest",
-					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1"},
+					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1", bridgerest.INF_SVC_MV_ID_LABEL: "2", bridgerest.INF_SVC_INF_SVC_ID_LABEL: "4"},
 				},
 				Spec:   serverapiv1beta1.InferenceServiceSpec{},
 				Status: serverapiv1beta1.InferenceServiceStatus{},
@@ -301,7 +301,7 @@ func TestStart(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mnist-v1",
 					Namespace: "ggmtest",
-					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1"},
+					Labels:    map[string]string{bridgerest.INF_SVC_RM_ID_LABEL: "1", bridgerest.INF_SVC_MV_ID_LABEL: "2", bridgerest.INF_SVC_INF_SVC_ID_LABEL: "4"},
 				},
 				Spec:   serverapiv1beta1.InferenceServiceSpec{},
 				Status: serverapiv1beta1.InferenceServiceStatus{},

--- a/pkg/rest/kfmr.go
+++ b/pkg/rest/kfmr.go
@@ -14,6 +14,7 @@ const (
 	GET_MODEL_VERSION_URI            = "/model_versions/%s"
 	INF_SVC_MV_ID_LABEL              = "modelregistry.opendatahub.io/model-version-id"
 	INF_SVC_RM_ID_LABEL              = "modelregistry.opendatahub.io/registered-model-id"
+	INF_SVC_INF_SVC_ID_LABEL         = "modelregistry.opendatahub.io/inference-service-id"
 	INF_SVC_IngressReady_CONDITION   = "IngressReady"
 	INF_SVC_PredictorReady_CONDITION = "PredictorReady"
 	INF_SVC_Ready_CONDITION          = "Ready"

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -10,7 +10,11 @@ import (
 	"strings"
 	"syscall"
 
+	serverapiv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
+
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
@@ -116,18 +120,28 @@ func SanitizeName(name string) string {
 
 }
 
-func KServeInferenceServiceMapping(rName, mName, isName string) bool {
-	// we have to special case the names a bit before sanitzing when mapping to the inference service name to match
-	// what kubeflow / kserve does; our sanitize already converts dots to empty chars, but we also need to a) convert
-	// spaces to hyphens, and b) make everything lower case
-	replacer := strings.NewReplacer(" ", "-")
-	rName = strings.ToLower(rName)
-	rName = replacer.Replace(rName)
-	rName = SanitizeName(rName)
-	mName = strings.ToLower(mName)
-	mName = replacer.Replace(mName)
-	mName = SanitizeName(mName)
-	key := fmt.Sprintf("%s-%s", rName, mName)
-    klog.Infof("KServeInferenceServiceMapping rName %s mName %s isName %s make key %s found %v", rName, mName, isName, key, key == isName)
-	return key == isName
+func KServeInferenceServiceMapping(rId, mId string, is *serverapiv1beta1.InferenceService) bool {
+	if is.Labels == nil {
+		return false
+	}
+
+	rmVal, rok := is.Labels[rest.INF_SVC_RM_ID_LABEL]
+	if !rok {
+		return false
+	}
+
+	if strings.TrimSpace(rId) != strings.TrimSpace(rmVal) {
+		return false
+	}
+
+    mvVal, mok := is.Labels[rest.INF_SVC_MV_ID_LABEL]
+    if !mok {
+         return false
+    }
+
+    if strings.TrimSpace(mId) != strings.TrimSpace(mvVal) {
+         return false
+    }
+
+    return true
 }


### PR DESCRIPTION
So I've got this fix broken up in three commits along these lines:

- rather than depend on shared name prefixes between the kserve and kubeflow inferencesservices, we know use the 3 labels set by the model registry operator on the kserve inferenceservice to correlate between the various Kubeflow objects (RegisteredModel, ModelVersion, etc.)

- during the background kubeflow flow, rather than just get the complete list of Kubeflow inference services, I list based on those 3 labels, using the controller caching client, so as to get the kserve InferenceService from the beginning

These two fixed the bug we saw in the rolling demo env as cited by RHDHPAI-1124, where the new llama stack model deployed from the model registry only had the Resource created, and not the Component/API.

Then, after looking at all this enough, it dawned on my that we were really populating the Models array of the ModelCatalog JSON schema incorrectly.

You can deploy multiple ModelVersion's of a RegisteredModel in parallel.  Hence having 2 ModelCatalogServers.  If the ModelArtifacts themselves provide for multilpe "models", like we see with some of our ollama based models outside of the RHOAI catalog), that does not translate into multiple RegisteredModels / ModelVersions i.e. the kubeflow REST API / data model.

So the third commit restructures so that there is one `ModelCatalog` per RegisteredModel/ModelVersion pairing, with only one entry in the Models array.

To date, the granite models I've seen deployed only have one model listed if you hit the `/v1/models` REST URI off of the models REST endpoint.  I'll coordinately with @johnmcollier this week to see if that is the case with the new llama model deployed from KServe (vs. the Ollama one we have on the cluster, etc.).  We'll then confirm with RHOAI model registries knowns expectations and how multiple models are or are not available from the RHOAI model catalog.

If the bridge needs to start getting into the business of querying the `/v1/models` REST URI, we'll level set and see if this is something we'll pursue for dev preview, or list as a restriction.