### PR TITLE
RHDHBUGS-2274: remove storage bootstrap from location on startup

### DIFF
--- a/pkg/cmd/server/location/server/server.go
+++ b/pkg/cmd/server/location/server/server.go
@@ -52,15 +52,6 @@ func NewImportLocationServer(stURL, port string, nf types.NormalizerFormat) *Imp
 	r.TrustedPlatform = "X-Forwarded-For"
 	r.Use(addRequestId())
 
-	// approach for implementing background processing with gin gonic discovered via some AI interaction lead to some
-	// timing issues with the periodic reconcile of the normalizer/storage-rest loop; decided not to start including
-	// the synchronization needed to sort that out.
-	// So instead, just doing a one time load attempt before registering the upsert handler to speed up location service
-	// population before 2 minute poll interval the loading of reconciled models form storage
-
-	klog.Info("one time load attempt from storage instead of waiting for the reconciliation loop")
-	i.loadFromStorage()
-
 	klog.Infof("NewImportLocationServer content len %d", len(i.content))
 	r.GET(util.ListURI, i.handleCatalogDiscoveryGet)
 	r.POST(util.UpsertURI, i.handleCatalogUpsertPost)

--- a/pkg/cmd/server/location/server/server_test.go
+++ b/pkg/cmd/server/location/server/server_test.go
@@ -1,49 +1,19 @@
 package server
 
 import (
-	"bytes"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
-	"sync"
-	"testing"
+     "bytes"
+     "io"
+     "net/http"
+     "net/url"
+     "strings"
+     "testing"
 
-	"github.com/gin-gonic/gin"
-	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
-	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
-	testgin "github.com/redhat-ai-dev/model-catalog-bridge/test/stub/gin-gonic"
-	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/storage"
-	"k8s.io/apimachinery/pkg/util/json"
+     "github.com/gin-gonic/gin"
+     "github.com/redhat-ai-dev/model-catalog-bridge/pkg/rest"
+     "github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
+     testgin "github.com/redhat-ai-dev/model-catalog-bridge/test/stub/gin-gonic"
+     "k8s.io/apimachinery/pkg/util/json"
 )
-
-func TestLoadFromStorage(t *testing.T) {
-	callback := &sync.Map{}
-	st := storage.CreateBridgeStorageREST(t, callback)
-	defer st.Close()
-	testWriter := testgin.NewTestResponseWriter()
-	ctx, eng := gin.CreateTestContext(testWriter)
-	ils := &ImportLocationServer{
-		router:  eng,
-		content: map[string]*ImportLocation{},
-		storage: storage.SetupBridgeStorageRESTClient(st),
-	}
-
-	done, err := ils.loadFromStorage()
-
-	common.AssertError(t, err)
-	common.AssertEqual(t, true, done)
-	common.AssertEqual(t, http.StatusOK, ctx.Writer.Status())
-
-	called := false
-	callback.Range(func(key, value any) bool {
-		called = true
-		return true
-	})
-	common.AssertEqual(t, true, called)
-	bodyBuf := testWriter.ResponseWriter.Body
-	common.AssertNotNil(t, bodyBuf)
-}
 
 func TestHandleCatalogDiscoveryGet(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
so the way thing evolved the location bootstrap from storage was almost always failing and the error message per https://issues.redhat.com/browse/RHDHBUGS-2274 was bothering field reps

validated via IDE that starting the containers in any order is okay

the normalizer's background update flow gets the location service what it needs even if location starts last 

left the boostrap method in for now in case we want to leverage it in some other fashion in the future