### PR TITLE
RHDHBUGS-2501: allow user to set value for rhdh.modelcatalog.io/model-name Resource annotation used by templates

### DIFF
--- a/pkg/cmd/cli/kserve/kserve.go
+++ b/pkg/cmd/cli/kserve/kserve.go
@@ -1,25 +1,25 @@
 package kserve
 
 import (
-     "bytes"
-     "context"
-     "encoding/json"
-     "fmt"
-     "io"
-     "net/url"
-     "os"
-     "strings"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
 
-     serverapiv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
-     "github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/backstage"
-     "github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
-     brdgtypes "github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
-     "github.com/redhat-ai-dev/model-catalog-bridge/pkg/util"
-     "github.com/redhat-ai-dev/model-catalog-bridge/schema/types/golang"
-     corev1 "k8s.io/api/core/v1"
-     "k8s.io/apimachinery/pkg/util/intstr"
-     "k8s.io/klog/v2"
-     "sigs.k8s.io/controller-runtime/pkg/client"
+	serverapiv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/backstage"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
+	brdgtypes "github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/util"
+	"github.com/redhat-ai-dev/model-catalog-bridge/schema/types/golang"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -406,9 +406,9 @@ func (m *ModelServerPopulator) GetAPI() *golang.API {
 		Type: m.ApiPop.GetType(),
 		URL:  routeExternalURL,
 	}
-    if api.Annotations == nil {
-         api.Annotations = map[string]string{}
-    }
+	if api.Annotations == nil {
+		api.Annotations = map[string]string{}
+	}
 	if len(svcInternalURL) > 0 {
 		api.Annotations[backstage.INTERNAL_SVC_URL] = svcInternalURL
 	}
@@ -665,8 +665,13 @@ func (m *ModelCatalogPopulator) GetModels() []golang.Model {
 	}
 
 	model.Annotations = make(map[string]string)
-    // avoid namespace prefix
-    model.Annotations[backstage.MODEL_NAME] = m.InferSvc.Name
+	// avoid namespace prefix
+	modelNameAlreadySet := m.InferSvc.Annotations[backstage.MODEL_NAME]
+	modelNameAlreadySet = strings.TrimSpace(modelNameAlreadySet)
+	model.Annotations[backstage.MODEL_NAME] = modelNameAlreadySet
+	if len(modelNameAlreadySet) == 0 {
+		model.Annotations[backstage.MODEL_NAME] = m.InferSvc.Name
+	}
 	techDocsUrl := mPop.GetTechDocs()
 	if techDocsUrl != nil && *techDocsUrl != "" {
 		model.Annotations[brdgtypes.TechDocsKey] = *techDocsUrl
@@ -691,8 +696,8 @@ func (m *ModelCatalogPopulator) GetModelServer() *golang.ModelServer {
 		Tags:           m.MSPop.GetTags(),
 		Usage:          m.MSPop.GetUsage(),
 	}
-    if ms.Annotations == nil {
-         ms.Annotations = map[string]string{}
-    }
-    return ms
+	if ms.Annotations == nil {
+		ms.Annotations = map[string]string{}
+	}
+	return ms
 }

--- a/pkg/cmd/cli/kserve/kserve_test.go
+++ b/pkg/cmd/cli/kserve/kserve_test.go
@@ -9,8 +9,8 @@ import (
 
 	serverapiv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	fakeservingv1beta1 "github.com/kserve/kserve/pkg/client/clientset/versioned/fake"
-     "github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/backstage"
-     "github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/cmd/cli/backstage"
+	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/config"
 	"github.com/redhat-ai-dev/model-catalog-bridge/pkg/types"
 	"github.com/redhat-ai-dev/model-catalog-bridge/schema/types/golang"
 	"github.com/redhat-ai-dev/model-catalog-bridge/test/stub/common"
@@ -68,9 +68,9 @@ func TestKserveBackstagePrinters(t *testing.T) {
 						Spec: "TBD",
 						Type: "openapi",
 						URL:  "https://kserve.com",
-                        Annotations: map[string]string{
-                             backstage.EXTERNAL_ROUTE_URL: "https://kserve.com",
-                        },
+						Annotations: map[string]string{
+							backstage.EXTERNAL_ROUTE_URL: "https://kserve.com",
+						},
 					},
 					Authentication: &falseVal,
 					Description:    "",
@@ -102,6 +102,7 @@ func TestKserveBackstagePrinters(t *testing.T) {
 						types.AnnotationPrefix + fixKeyForAnnotation(types.TechDocsKey):    types.TechDocsKey,
 						types.AnnotationPrefix + fixKeyForAnnotation(types.LicenseKey):     types.LicenseKey,
 						types.AnnotationPrefix + fixKeyForAnnotation(types.DescriptionKey): types.DescriptionKey,
+						backstage.MODEL_NAME: "foo-foo",
 					},
 				},
 				Spec: serverapiv1beta1.InferenceServiceSpec{
@@ -196,6 +197,9 @@ func TestKserveBackstagePrinters(t *testing.T) {
 						Support:     &support,
 						Training:    &training,
 						Usage:       &usage,
+						Annotations: map[string]string{
+							backstage.MODEL_NAME: "foo-foo",
+						},
 					},
 				},
 				ModelServer: &golang.ModelServer{
@@ -203,9 +207,9 @@ func TestKserveBackstagePrinters(t *testing.T) {
 						Spec: types.APISpecKey,
 						Type: golang.Openapi,
 						URL:  "https://kserve.com",
-                        Annotations: map[string]string{
-                             backstage.EXTERNAL_ROUTE_URL: "https://kserve.com/",
-                        },
+						Annotations: map[string]string{
+							backstage.EXTERNAL_ROUTE_URL: "https://kserve.com/",
+						},
 					},
 					Authentication: &falseVal,
 					Description:    types.DescriptionKey,
@@ -322,7 +326,7 @@ func TestKserveBackstagePrinters(t *testing.T) {
 					if tmAPI.Annotations != nil {
 						if len(tmAPI.Annotations) != len(tmAPI.Annotations) {
 							t.Logf("api num of annotations mismatch %s tm %d om %d", tc.name, len(tmAPI.Annotations), len(omAPI.Annotations))
-                            common.AssertEqual(t, len(tmAPI.Annotations), len(omAPI.Annotations))
+							common.AssertEqual(t, len(tmAPI.Annotations), len(omAPI.Annotations))
 						}
 					}
 				}

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr.go
@@ -269,7 +269,20 @@ func (m *ModelCatalogPopulator) GetModels() []golang.Model {
 	if model.Annotations == nil {
 		model.Annotations = make(map[string]string)
 	}
+
 	model.Annotations[backstage.MODEL_NAME] = model.Name
+	// see if there are overriddes in the custom props
+	props := mPop.RegisteredModel.GetCustomProperties()
+	modelName, ok := props[backstage.MODEL_NAME]
+	if ok && modelName.MetadataStringValue != nil {
+		model.Annotations[backstage.MODEL_NAME] = modelName.MetadataStringValue.StringValue
+	}
+	props = mPop.ModelVersion.GetCustomProperties()
+	modelName, ok = props[backstage.MODEL_NAME]
+	if ok && modelName.MetadataStringValue != nil {
+		model.Annotations[backstage.MODEL_NAME] = modelName.MetadataStringValue.StringValue
+	}
+
 	techDocsUrl := mPop.GetTechDocs()
 	if techDocsUrl != nil && *techDocsUrl != "" {
 		model.Annotations[brdgtypes.TechDocsKey] = *techDocsUrl

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
@@ -60,6 +60,10 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 							Training:    &training,
 							License:     &license,
 							Usage:       &usage,
+							Annotations: map[string]string{
+								backstage.MODEL_NAME: "mnist-v1",
+								types.TechDocsKey:    "https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs",
+							},
 						},
 					},
 				},
@@ -76,6 +80,9 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 							Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v3", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
 							Training:    &training,
 							Usage:       &usage,
+							Annotations: map[string]string{
+								backstage.MODEL_NAME: "foo-foo",
+							},
 						},
 					},
 				},
@@ -98,6 +105,10 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 							Training:    &training,
 							License:     &license,
 							Usage:       &usage,
+							Annotations: map[string]string{
+								backstage.MODEL_NAME: "mnist-v1",
+								types.TechDocsKey:    "https://github.com/redhat-ai-dev/granite-3.1-8b-lab-docs",
+							},
 						},
 					},
 					ModelServer: &golang.ModelServer{
@@ -131,6 +142,9 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 							Tags:        []string{"rhoai", "rhoai-model-registry", "matteos-lightweight-test-model", "v3", "grpc", "last-modified-time-2025-02-25-19-45-29-959"},
 							Training:    &training,
 							Usage:       &usage,
+							Annotations: map[string]string{
+								backstage.MODEL_NAME: "foo-foo",
+							},
 						},
 					},
 				},
@@ -326,9 +340,18 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 								continue
 							}
 						}
+						tcAnnotations := tcModel.Annotations == nil
+						outAnnotations := outModel.Annotations == nil
+						if tcAnnotations != outAnnotations {
+							t.Logf("annotations nil mismatch oidx %d", oidx)
+						}
 						if tcModel.Annotations != nil {
 							if tcModel.Annotations[types.TechDocsKey] != outModel.Annotations[types.TechDocsKey] {
-								t.Logf("annotation mismatch oidx %d", oidx)
+								t.Logf("annotation tech docs key mismatch oidx %d", oidx)
+								continue
+							}
+							if tcModel.Annotations[backstage.MODEL_NAME] != outModel.Annotations[backstage.MODEL_NAME] {
+								t.Logf("annotation model name mismatch oidx %d", oidx)
 								continue
 							}
 						}
@@ -388,10 +411,10 @@ func TestLoopOverKRMR_JsonArray(t *testing.T) {
 								continue
 							}
 							if tms.API.Annotations != nil {
-                                 if len(tms.API.Annotations) != len(oms.API.Annotations) {
-                                      t.Logf("svr annotations len mismatch oidx %d", oidx)
-                                      continue
-                                 }
+								if len(tms.API.Annotations) != len(oms.API.Annotations) {
+									t.Logf("svr annotations len mismatch oidx %d", oidx)
+									continue
+								}
 							}
 							if tms.API.Spec != oms.API.Spec {
 								t.Logf("svr api spec mismatch oidx %d", oidx)

--- a/test/stub/common/constants.go
+++ b/test/stub/common/constants.go
@@ -1823,6 +1823,11 @@ const (
                       "metadataType":"MetadataStringValue",
                       "string_value":"https://mymodel.io/welcome"
                   },
+                  "rhdh.modelcatalog.io/model-name":
+                  {
+                      "metadataType":"MetadataStringValue",
+                      "string_value":"foo-foo"
+                  },
                   "API Spec":
                   {
                       "metadataType":"MetadataStringValue",


### PR DESCRIPTION

this change allows for the user to override the default for the rhdh.modelcatalog.io/model-name annotation via
- use of Resource Model or Model Version custom properties (model version takes precedence) when the model registry is involved
- use of InferenceService CRD annotations when only kserve is involved

some field testing uncovered scenarios where if the user changes defaults when deploying a model from the RHOAI dashboard, the default value we were providing for the annotation would in fact not line up with the name of the model in the KServe container per what is listed from the /v1/models URI or used via the /v1/completions URI

I also ran gofmt on some files so I suggest reviewing with whitespace disabled 

@evanshortiss @maysunfaisal FYI